### PR TITLE
Remove immutable to allow wal checkpoints

### DIFF
--- a/shelfmark/core/admin_routes.py
+++ b/shelfmark/core/admin_routes.py
@@ -134,7 +134,7 @@ def _sync_all_cwa_users(user_db: UserDB) -> dict[str, int]:
         raise FileNotFoundError(msg)
 
     db_path = os.fspath(CWA_DB_PATH)
-    db_uri = f"file:{db_path}?mode=ro&immutable=1"
+    db_uri = f"file:{db_path}?mode=ro"
     conn = sqlite3.connect(db_uri, uri=True)
     try:
         cur = conn.cursor()

--- a/shelfmark/main.py
+++ b/shelfmark/main.py
@@ -2091,7 +2091,7 @@ def api_login() -> Response | tuple[Response, int]:
 
             try:
                 db_path = os.fspath(CWA_DB_PATH)
-                db_uri = f"file:{db_path}?mode=ro&immutable=1"
+                db_uri = f"file:{db_path}?mode=ro"
                 conn = sqlite3.connect(db_uri, uri=True)
                 cur = conn.cursor()
                 cur.execute("SELECT password, role, email FROM user WHERE name = ?", (username,))


### PR DESCRIPTION
Fixes https://github.com/calibrain/shelfmark/issues/915

## Description

Remove immutable=1 to allow wal checkpoints to fire and get latest auth info.

Note db is still in readonly mode, thanks to mode=ro

## Test case

1. Run CWA/CW
2. Change Admin password from admin/admin123 to anything else
3. Run shelfmark with CWA db auth
4. Shelfmark should be able to login after password change