### PR TITLE
fix(transmission): handle completion when seed ratio is 0

### DIFF
--- a/shelfmark/download/clients/transmission.py
+++ b/shelfmark/download/clients/transmission.py
@@ -316,8 +316,9 @@ class TransmissionClient(DownloadClient):
 
             state, message = status_map.get(status_value, ("downloading", "Downloading"))
             progress = torrent.percent_done * 100
-            # Only mark complete when seeding - seed pending means files still being moved
-            complete = progress >= _SEEDING_PROGRESS_PERCENT and status_value == "seeding"
+            # Only mark complete when seeding or stopped (e.g. if seed limit/ratio is 0)
+            # and progress is complete. seed pending means files still being moved
+            complete = progress >= _SEEDING_PROGRESS_PERCENT and status_value in ("seeding", "stopped")
 
             if complete:
                 message = "Complete"


### PR DESCRIPTION
  ## Description
  When using Transmission as the torrent client with a seed ratio/limit set to `0` (so it immediately stops seeding upon completion), the torrent moves directly to the `"stopped"` state upon reaching 100% completion.
  Previously, `transmission.py` strictly checked that the state was `"seeding"` to mark it complete:
  ```python
  complete = progress >= _SEEDING_PROGRESS_PERCENT and status_value == "seeding"
  ```
  Because of this, the completed torrent was never marked as finished, and Shelfmark got stuck in an infinite polling loop. After 5 minutes, the orchestrator's stall detector triggered and cancelled the download in the queue (even though the files were fully downloaded and sitting in
  the complete directory).
  ## Fix
  Updated the completion check in `shelfmark/download/clients/transmission.py` to allow `"stopped"` as a completed state as long as progress is 100%. This aligns it with how other torrent clients (like qBittorrent and Deluge) handle completion:
  ```python
  complete = progress >= _SEEDING_PROGRESS_PERCENT and status_value in ("seeding", "stopped")
  ```
  ## Related Issue
  Fixes #1022