### PR TITLE
Preserve supplementary groups by using `runuser` for passwd-backed users instead of `gosu`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,8 +139,12 @@ if [ "$RUN_AS_NON_ROOT" = "true" ]; then
     if [ -z "$USERNAME" ]; then
         USERNAME="$RUN_UID"
         echo "No passwd entry found for UID $RUN_UID; using numeric identity"
+        TARGET_USER_SPEC="${RUN_UID}:${RUN_GID}"
+        USE_GOSU_FALLBACK="true"
+    else
+        TARGET_USER_SPEC="$USERNAME"
+        USE_GOSU_FALLBACK="false"
     fi
-    TARGET_USER_SPEC="${RUN_UID}:${RUN_GID}"
 else
     # Determine user ID with proper precedence:
     # 1. PUID (LinuxServer.io standard - recommended)
@@ -190,8 +194,12 @@ else
     USERNAME=$(getent passwd "$RUN_UID" | cut -d: -f1)
     if [ -z "$USERNAME" ]; then
         USERNAME="$RUN_UID"
+        TARGET_USER_SPEC="${RUN_UID}:${RUN_GID}"
+        USE_GOSU_FALLBACK="true"
+    else
+        TARGET_USER_SPEC="$USERNAME"
+        USE_GOSU_FALLBACK="false"
     fi
-    TARGET_USER_SPEC="${RUN_UID}:${RUN_GID}"
 fi
 
 # Avoid unnecessary gosu hops when we're already running as the target user.
@@ -208,7 +216,11 @@ needs_user_switch() {
 
 run_as_target_user() {
     if needs_user_switch; then
-        gosu "$TARGET_USER_SPEC" "$@"
+        if [ "$USE_GOSU_FALLBACK" = "true" ]; then
+            gosu "$TARGET_USER_SPEC" "$@"
+        else
+            runuser -u "$USERNAME" -- "$@"
+        fi
         return $?
     fi
 
@@ -217,7 +229,11 @@ run_as_target_user() {
 
 exec_as_target_user() {
     if needs_user_switch; then
-        exec gosu "$TARGET_USER_SPEC" "$@"
+        if [ "$USE_GOSU_FALLBACK" = "true" ]; then
+            exec gosu "$TARGET_USER_SPEC" "$@"
+        else
+            exec runuser -u "$USERNAME" -- "$@"
+        fi
     fi
 
     exec "$@"


### PR DESCRIPTION
The entrypoint script strips supplementary groups from the appuser user. This mean I was getting Errno13 dir not writeable errors (https://github.com/calibrain/shelfmark/issues/951#issuecomment-4505403546) despite my running user able to create/delete files in the destination folders I had chosen and mapped in my compose file. I use NFSv4 ACLs to give users file permissions which seem to not be supported by gosu.

Using `runuser` on the username instead resolved this issue. `gosu` is used where no passwd entry exists.

There may be a more intuitive solution but I am not familiar enough with the topic.