### PR TITLE
Added language detection throught the distant path of AA.

### DIFF
--- a/shelfmark/config/settings.py
+++ b/shelfmark/config/settings.py
@@ -1440,6 +1440,15 @@ def download_source_settings() -> list[SettingsField]:
             ),
             default=False,
         ),
+        CheckboxField(
+            key="DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH",
+            label="Detect Language From Distant Path",
+            description=(
+                "When language metadata is missing, parse the distant path and set language "
+                "from tags like [BD FR]. Falls back to unknown when not detected."
+            ),
+            default=False,
+        ),
         PasswordField(
             key="AA_DONATOR_KEY",
             label="Account Donator Key",

--- a/shelfmark/config/settings.py
+++ b/shelfmark/config/settings.py
@@ -1445,7 +1445,8 @@ def download_source_settings() -> list[SettingsField]:
             label="Detect Language From Distant Path",
             description=(
                 "When language metadata is missing, parse the distant path and set language "
-                "from tags like [BD FR]. Falls back to unknown when not detected."
+                "from tags like [BD FR]. Falls back to unknown when not detected. "
+                "Note: source-side language filters still apply and may exclude poorly tagged rows."
             ),
             default=False,
         ),

--- a/shelfmark/release_sources/direct_download.py
+++ b/shelfmark/release_sources/direct_download.py
@@ -432,11 +432,17 @@ def _normalize_requested_languages(languages: list[str] | None) -> set[str]:
 
 
 def _book_matches_requested_languages(book_language: str | None, requested: set[str]) -> bool:
-    """Return True when a book language matches normalized requested filters."""
+    """Return True when a book language matches normalized requested filters.
+
+    A book whose language is unknown (None) passes through: the server-side
+    ``&lang=`` filter already constrained the result set, so dropping rows
+    that simply lack metadata would hide relevant results.
+    """
     if not requested:
         return True
     if not book_language:
-        return False
+        # Language unknown but returned by the server-side filter → accept.
+        return True
 
     aliases = _language_alias_to_code()
     normalized_book = aliases.get(_normalize_language_token(book_language), _normalize_language_token(book_language))
@@ -611,9 +617,14 @@ def search_books(query: str, filters: SearchFilters) -> list[BrowseRecord]:
     path_language_enabled = _is_language_from_path_enabled()
     requested_langs = _normalize_requested_languages(filters.lang)
 
-    for value in filters.lang or []:
-        if value and value != "all":
-            filters_query += f"&lang={quote(value)}"
+    # When path-language inference is enabled and a specific language is requested,
+    # skip the server-side &lang= filter: many lgli/archive files have no language
+    # metadata on AA's side and would be excluded before we can infer their language
+    # from the distant path.  Local filtering (below) handles the narrowing instead.
+    if not (path_language_enabled and requested_langs):
+        for value in filters.lang or []:
+            if value and value != "all":
+                filters_query += f"&lang={quote(value)}"
 
     if filters.sort and filters.sort != "relevance":
         filters_query += f"&sort={quote(filters.sort)}"
@@ -767,16 +778,9 @@ def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
                 "unknown" if detected_from_path is None else "detected",
             )
 
-        if (
-            title is None
-            or author is None
-            or publisher is None
-            or year is None
-            or language is None
-            or content is None
-            or file_format is None
-            or size is None
-        ):
+        # Only truly required fields — all others are optional in BrowseRecord.
+        # Rows with sparse metadata (e.g. lgli sources) must not be silently dropped.
+        if title is None or file_format is None:
             return None
 
         return BrowseRecord(

--- a/shelfmark/release_sources/direct_download.py
+++ b/shelfmark/release_sources/direct_download.py
@@ -198,8 +198,23 @@ _DOWNLOAD_SOURCES = [
 _SOURCE_FAILURE_THRESHOLD = 4
 _MIN_VALID_FILE_SIZE = 10 * 1024
 _AA_COUNTDOWN_MAX_SECONDS = 300
+_DISTANT_PATH_EXTENSIONS = (
+    "epub",
+    "mobi",
+    "azw3",
+    "fb2",
+    "djvu",
+    "cbz",
+    "cbr",
+    "pdf",
+    "zip",
+    "rar",
+    "m4b",
+    "mp3",
+)
+_DISTANT_PATH_EXTENSION_PATTERN = "|".join(re.escape(extension) for extension in _DISTANT_PATH_EXTENSIONS)
 _DISTANT_PATH_PATTERN = re.compile(
-    r"(?:[A-Za-z0-9._-]+/)?[A-Za-z]:(?:\\|/)[^\n\r<>\"]+?\.(?:epub|mobi|azw3|fb2|djvu|cbz|cbr|pdf|zip|rar|m4b|mp3)\b",
+    rf"(?:[A-Za-z0-9._-]+/)?[A-Za-z]:(?:\\|/)[^\n\r<>\"]+?\.(?:{_DISTANT_PATH_EXTENSION_PATTERN})\b",
     re.IGNORECASE,
 )
 _DISTANT_PATH_FALLBACK_PATTERN = re.compile(

--- a/shelfmark/release_sources/direct_download.py
+++ b/shelfmark/release_sources/direct_download.py
@@ -4,8 +4,10 @@ import itertools
 import json
 import re
 import time
+import unicodedata
 from dataclasses import replace
 from http import HTTPStatus
+from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, NoReturn, TypedDict
 from urllib.parse import quote, urlparse
 
@@ -196,12 +198,221 @@ _DOWNLOAD_SOURCES = [
 _SOURCE_FAILURE_THRESHOLD = 4
 _MIN_VALID_FILE_SIZE = 10 * 1024
 _AA_COUNTDOWN_MAX_SECONDS = 300
+_DISTANT_PATH_PATTERN = re.compile(
+    r"(?:[A-Za-z0-9._-]+/)?[A-Za-z]:(?:\\|/)[^\n\r<>\"]+?\.(?:epub|mobi|azw3|fb2|djvu|cbz|cbr|pdf|zip|rar|m4b|mp3)\b",
+    re.IGNORECASE,
+)
+_DISTANT_PATH_FALLBACK_PATTERN = re.compile(
+    r"(?:[A-Za-z0-9._-]+/)?[A-Za-z]:(?:\\|/)[^\n\r<>\"]+",
+    re.IGNORECASE,
+)
+_LANGUAGE_CODE_TOKEN_PATTERN = re.compile(
+    r"(?:^|[\s_./\\\-\[(])([A-Za-z]{2,3})(?=$|[\s_./\\\-)\]])"
+)
+_BRACKETED_LANGUAGE_CODE_PATTERN = re.compile(
+    r"\[(?:bd[\s._-]*)?([A-Za-z]{2,3})\]",
+    re.IGNORECASE,
+)
+_KEYED_LANGUAGE_CODE_PATTERN = re.compile(
+    r"\b(?:bd|lang(?:uage)?)\s*[:._-]?\s*([A-Za-z]{2,3})\b",
+    re.IGNORECASE,
+)
+_LANGUAGE_NAME_TOKEN_PATTERN = re.compile(r"[a-z]{3,}(?:-[a-z0-9]+)?")
+_LANGUAGE_ALIAS_TO_CODE: dict[str, str] | None = None
+_LANGUAGE_PLACEHOLDERS = frozenset({"", "-", "--", "—", "unknown", "unk", "n/a", "na"})
+_AMBIGUOUS_SHORT_LANGUAGE_CODES = frozenset({"de", "en", "it", "la", "no", "or", "is", "in"})
 
 # Sources that require Cloudflare bypass
 _CF_BYPASS_REQUIRED = frozenset({"aa-slow-nowait", "aa-slow-wait", "zlib", "welib"})
 
 # Sources whose URLs come from AA page (multiple mirrors)
 _AA_PAGE_SOURCES = frozenset({"aa-slow-nowait", "aa-slow-wait"})
+
+
+def _is_language_from_path_enabled() -> bool:
+    """Return True when distant-path language detection is enabled."""
+    return bool(config.get("DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH", False))
+
+
+def _normalize_language_token(value: str) -> str:
+    """Normalize language tokens for map lookup."""
+    normalized = value.strip().lower()
+    for dash in ("‑", "–", "—", "−"):
+        normalized = normalized.replace(dash, "-")
+    return normalized
+
+
+def _fold_text(value: str) -> str:
+    """Fold unicode text to a simple ASCII-ish lowercase string for matching."""
+    normalized = unicodedata.normalize("NFKD", value)
+    return "".join(char for char in normalized if not unicodedata.combining(char)).lower()
+
+
+def _language_alias_to_code() -> dict[str, str]:
+    """Build alias->code map from bundled language metadata."""
+    global _LANGUAGE_ALIAS_TO_CODE
+    if _LANGUAGE_ALIAS_TO_CODE is not None:
+        return _LANGUAGE_ALIAS_TO_CODE
+
+    mapping: dict[str, str] = {}
+    data_path = Path(__file__).resolve().parents[2] / "data" / "book-languages.json"
+
+    try:
+        raw = json.loads(data_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        _LANGUAGE_ALIAS_TO_CODE = {}
+        return _LANGUAGE_ALIAS_TO_CODE
+
+    if not isinstance(raw, list):
+        _LANGUAGE_ALIAS_TO_CODE = {}
+        return _LANGUAGE_ALIAS_TO_CODE
+
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+
+        code = _normalize_language_token(str(item.get("code", "")))
+        name = _normalize_language_token(str(item.get("language", "")))
+        if not code:
+            continue
+
+        mapping.setdefault(code, code)
+        mapping.setdefault(code.replace("-", "_"), code)
+        mapping.setdefault(code.split("-")[0], code)
+        mapping.setdefault(_fold_text(code), code)
+        if name:
+            mapping.setdefault(name, code)
+            mapping.setdefault(_fold_text(name), code)
+
+    _LANGUAGE_ALIAS_TO_CODE = mapping
+    return _LANGUAGE_ALIAS_TO_CODE
+
+
+def _extract_distant_path(row: Tag) -> str | None:
+    """Extract distant path hints from a direct-download search row."""
+    def _normalize_candidate(text: str) -> str:
+        # Some mirrors render paths with spaces around separators (e.g. "V: \comics \ ...").
+        normalized = re.sub(r"\s*([\\/])\s*", r"\1", text)
+        normalized = re.sub(r":\s*([\\/])", r":\1", normalized)
+        normalized = re.sub(
+            r"\s+\.(epub|mobi|azw3|fb2|djvu|cbz|cbr|pdf|zip|rar|m4b|mp3)\b",
+            r".\1",
+            normalized,
+            flags=re.IGNORECASE,
+        )
+        return normalized
+
+    candidates = [row.get_text(" ", strip=True)]
+    for cell in row.find_all("td"):
+        cell_text = cell.get_text(" ", strip=True)
+        if cell_text:
+            candidates.append(cell_text)
+
+    best: str | None = None
+    for text in candidates:
+        normalized_text = _normalize_candidate(text)
+        for match in _DISTANT_PATH_PATTERN.findall(normalized_text):
+            candidate = match.strip().rstrip(".,;")
+            if best is None or len(candidate) > len(best):
+                best = candidate
+
+    if best is not None:
+        return best
+
+    for text in candidates:
+        normalized_text = _normalize_candidate(text)
+        for match in _DISTANT_PATH_FALLBACK_PATTERN.findall(normalized_text):
+            candidate = match.strip().rstrip(".,;")
+            if best is None or len(candidate) > len(best):
+                best = candidate
+
+    return best
+
+
+def _detect_language_from_distant_path(path: str | None) -> str | None:
+    """Infer a language code from distant-path tags such as [BD FR]."""
+    if not path:
+        return None
+
+    aliases = _language_alias_to_code()
+    if not aliases:
+        return None
+
+    folded_path = _fold_text(path)
+
+    # Strongest signal: explicit bracket tags like [Fr], [BD FR], [EN].
+    for code in _BRACKETED_LANGUAGE_CODE_PATTERN.findall(path):
+        normalized = _normalize_language_token(code)
+        if normalized in aliases:
+            return aliases[normalized]
+
+    # Strong signal: explicit keyed markers like "BD FR" or "language: fr".
+    for code in _KEYED_LANGUAGE_CODE_PATTERN.findall(path):
+        normalized = _normalize_language_token(code)
+        if normalized in aliases:
+            return aliases[normalized]
+
+    # Medium signal: full language names (french, francais, deutsch, etc.).
+    for token in _LANGUAGE_NAME_TOKEN_PATTERN.findall(folded_path):
+        normalized = _normalize_language_token(token)
+        if normalized in aliases:
+            return aliases[normalized]
+
+    for code in _LANGUAGE_CODE_TOKEN_PATTERN.findall(path):
+        normalized = _normalize_language_token(code)
+        if normalized in _AMBIGUOUS_SHORT_LANGUAGE_CODES:
+            # Avoid false positives from common words: "de", "en", etc.
+            continue
+        if normalized in aliases:
+            return aliases[normalized]
+
+    return None
+
+
+def _is_missing_or_placeholder_language(language: str | None) -> bool:
+    """Return True when language should be inferred from distant path."""
+    if language is None:
+        return True
+    return _normalize_language_token(language) in _LANGUAGE_PLACEHOLDERS
+
+
+def _normalize_requested_languages(languages: list[str] | None) -> set[str]:
+    """Normalize requested language filters to canonical codes when possible."""
+    if not languages:
+        return set()
+
+    aliases = _language_alias_to_code()
+    normalized: set[str] = set()
+
+    for value in languages:
+        token = _normalize_language_token(str(value))
+        if not token or token == "all":
+            continue
+        normalized.add(aliases.get(token, token))
+
+    return normalized
+
+
+def _book_matches_requested_languages(book_language: str | None, requested: set[str]) -> bool:
+    """Return True when a book language matches normalized requested filters."""
+    if not requested:
+        return True
+    if not book_language:
+        return False
+
+    aliases = _language_alias_to_code()
+    normalized_book = aliases.get(_normalize_language_token(book_language), _normalize_language_token(book_language))
+    return normalized_book in requested
+
+
+def _short_debug(value: str | None, *, limit: int = 180) -> str:
+    """Compact values for row-level debug logs."""
+    if value is None:
+        return "<none>"
+    text = value.replace("\n", "\\n").replace("\r", "\\r").strip()
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}..."
 
 
 def _is_configured_zlib_link(url: str) -> bool:
@@ -359,10 +570,15 @@ def search_books(query: str, filters: SearchFilters) -> list[BrowseRecord]:
         query_html = quote(f"({isbns}) {query}")
 
     filters_query = ""
+    path_language_enabled = _is_language_from_path_enabled()
+    requested_langs = _normalize_requested_languages(filters.lang)
 
-    for value in filters.lang or []:
-        if value and value != "all":
-            filters_query += f"&lang={quote(value)}"
+    # When path-language inference is enabled, language filtering must happen
+    # after row parsing, otherwise source-side lang filters drop rows too early.
+    if not (path_language_enabled and requested_langs):
+        for value in filters.lang or []:
+            if value and value != "all":
+                filters_query += f"&lang={quote(value)}"
 
     if filters.sort and filters.sort != "relevance":
         filters_query += f"&sort={quote(filters.sort)}"
@@ -428,6 +644,11 @@ def search_books(query: str, filters: SearchFilters) -> list[BrowseRecord]:
         )
     )
 
+    if path_language_enabled and requested_langs:
+        books = [
+            book for book in books if _book_matches_requested_languages(book.language, requested_langs)
+        ]
+
     return books
 
 
@@ -471,6 +692,8 @@ def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
         if not record_id:
             return None
 
+        distant_path = _extract_distant_path(row)
+
         preview_img = cells[0].find("img")
         preview = _get_attr(preview_img, "src") if isinstance(preview_img, Tag) else None
 
@@ -482,6 +705,31 @@ def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
         content = _first_stripped_text(cells[8].find("span"))
         file_format = _first_stripped_text(cells[9].find("span"))
         size = _first_stripped_text(cells[10].find("span"))
+
+        detected_from_path = _detect_language_from_distant_path(distant_path)
+
+        # Temporary visual diagnostics for field mapping and path-language inference.
+        if _is_language_from_path_enabled():
+            logger.info(
+                "DD lang debug | id=%s | title=%s | raw_lang=%s | detected_from_path=%s | distant_path=%s | cell11=%s | row=%s",
+                record_id,
+                _short_debug(title),
+                _short_debug(language),
+                _short_debug(detected_from_path),
+                _short_debug(distant_path, limit=260),
+                _short_debug(cells[10].get_text(" ", strip=True), limit=140),
+                _short_debug(row.get_text(" ", strip=True), limit=260),
+            )
+
+        if _is_language_from_path_enabled() and _is_missing_or_placeholder_language(language):
+            language = detected_from_path or "unknown"
+
+            logger.info(
+                "DD lang debug resolved | id=%s | final_lang=%s | fallback=%s",
+                record_id,
+                _short_debug(language),
+                "unknown" if detected_from_path is None else "detected",
+            )
 
         if (
             title is None
@@ -507,6 +755,7 @@ def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
             content=content.lower() if content else None,
             format=file_format.lower() if file_format else None,
             size=size,
+            download_path=distant_path,
         )
     except (AttributeError, IndexError, KeyError, TypeError) as e:
         logger.error_trace(f"Error parsing search result row: {e}")

--- a/shelfmark/release_sources/direct_download.py
+++ b/shelfmark/release_sources/direct_download.py
@@ -3,6 +3,7 @@
 import itertools
 import json
 import re
+import threading
 import time
 import unicodedata
 from dataclasses import replace
@@ -232,9 +233,10 @@ _KEYED_LANGUAGE_CODE_PATTERN = re.compile(
     r"\b(?:bd|lang(?:uage)?)\s*[:._-]?\s*([A-Za-z]{2,3})\b",
     re.IGNORECASE,
 )
-_LANGUAGE_NAME_TOKEN_PATTERN = re.compile(r"[a-z]{3,}(?:-[a-z0-9]+)?")
+_LANGUAGE_NAME_TOKEN_PATTERN = re.compile(r"[a-z]{4,}(?:-[a-z0-9]+)?")
 _LANGUAGE_ALIAS_TO_CODE: dict[str, str] | None = None
-_LANGUAGE_PLACEHOLDERS = frozenset({"", "-", "--", "—", "unknown", "unk", "n/a", "na"})
+_LANGUAGE_ALIAS_LOCK = threading.Lock()
+_LANGUAGE_PLACEHOLDERS = frozenset({"", "-", "--", "unknown", "unk", "n/a", "na"})
 _AMBIGUOUS_SHORT_LANGUAGE_CODES = frozenset({"de", "en", "it", "la", "no", "or", "is", "in"})
 
 # Sources that require Cloudflare bypass
@@ -266,45 +268,54 @@ def _fold_text(value: str) -> str:
 def _language_alias_to_code() -> dict[str, str]:
     """Build alias->code map from bundled language metadata."""
     global _LANGUAGE_ALIAS_TO_CODE
-    if _LANGUAGE_ALIAS_TO_CODE is not None:
+    cached = _LANGUAGE_ALIAS_TO_CODE
+    if cached is not None:
+        return cached
+
+    with _LANGUAGE_ALIAS_LOCK:
+        cached = _LANGUAGE_ALIAS_TO_CODE
+        if cached is not None:
+            return cached
+
+        mapping: dict[str, str] = {}
+        data_path = Path(__file__).resolve().parents[2] / "data" / "book-languages.json"
+
+        try:
+            raw = json.loads(data_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            _LANGUAGE_ALIAS_TO_CODE = {}
+            return _LANGUAGE_ALIAS_TO_CODE
+
+        if not isinstance(raw, list):
+            _LANGUAGE_ALIAS_TO_CODE = {}
+            return _LANGUAGE_ALIAS_TO_CODE
+
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+
+            code = _normalize_language_token(str(item.get("code", "")))
+            name = _normalize_language_token(str(item.get("language", "")))
+            if not code:
+                continue
+
+            mapping.setdefault(code, code)
+            mapping.setdefault(code.replace("-", "_"), code)
+            mapping.setdefault(code.split("-")[0], code)
+            mapping.setdefault(_fold_text(code), code)
+            if name:
+                mapping.setdefault(name, code)
+                mapping.setdefault(_fold_text(name), code)
+
+        _LANGUAGE_ALIAS_TO_CODE = mapping
         return _LANGUAGE_ALIAS_TO_CODE
 
-    mapping: dict[str, str] = {}
-    data_path = Path(__file__).resolve().parents[2] / "data" / "book-languages.json"
 
-    try:
-        raw = json.loads(data_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError, TypeError):
-        _LANGUAGE_ALIAS_TO_CODE = {}
-        return _LANGUAGE_ALIAS_TO_CODE
-
-    if not isinstance(raw, list):
-        _LANGUAGE_ALIAS_TO_CODE = {}
-        return _LANGUAGE_ALIAS_TO_CODE
-
-    for item in raw:
-        if not isinstance(item, dict):
-            continue
-
-        code = _normalize_language_token(str(item.get("code", "")))
-        name = _normalize_language_token(str(item.get("language", "")))
-        if not code:
-            continue
-
-        mapping.setdefault(code, code)
-        mapping.setdefault(code.replace("-", "_"), code)
-        mapping.setdefault(code.split("-")[0], code)
-        mapping.setdefault(_fold_text(code), code)
-        if name:
-            mapping.setdefault(name, code)
-            mapping.setdefault(_fold_text(name), code)
-
-    _LANGUAGE_ALIAS_TO_CODE = mapping
-    return _LANGUAGE_ALIAS_TO_CODE
-
-
-def _extract_distant_path(row: Tag) -> str | None:
+def _extract_distant_path(row: Tag, *, enabled: bool) -> str | None:
     """Extract distant path hints from a direct-download search row."""
+    if not enabled:
+        return None
+
     def _normalize_candidate(text: str) -> str:
         # Some mirrors render paths with spaces around separators (e.g. "V: \comics \ ...").
         normalized = re.sub(r"\s*([\\/])\s*", r"\1", text)
@@ -354,24 +365,36 @@ def _detect_language_from_distant_path(path: str | None) -> str | None:
         return None
 
     folded_path = _fold_text(path)
+    strong_candidates: list[str] = []
 
     # Strongest signal: explicit bracket tags like [Fr], [BD FR], [EN].
     for code in _BRACKETED_LANGUAGE_CODE_PATTERN.findall(path):
         normalized = _normalize_language_token(code)
         if normalized in aliases:
-            return aliases[normalized]
+            strong_candidates.append(aliases[normalized])
 
     # Strong signal: explicit keyed markers like "BD FR" or "language: fr".
     for code in _KEYED_LANGUAGE_CODE_PATTERN.findall(path):
         normalized = _normalize_language_token(code)
         if normalized in aliases:
-            return aliases[normalized]
+            strong_candidates.append(aliases[normalized])
+
+    non_ambiguous_strong = [
+        candidate for candidate in strong_candidates if candidate not in _AMBIGUOUS_SHORT_LANGUAGE_CODES
+    ]
+    if non_ambiguous_strong:
+        return non_ambiguous_strong[0]
 
     # Medium signal: full language names (french, francais, deutsch, etc.).
     for token in _LANGUAGE_NAME_TOKEN_PATTERN.findall(folded_path):
         normalized = _normalize_language_token(token)
         if normalized in aliases:
-            return aliases[normalized]
+            candidate = aliases[normalized]
+            if candidate not in _AMBIGUOUS_SHORT_LANGUAGE_CODES:
+                return candidate
+
+    if strong_candidates:
+        return strong_candidates[0]
 
     for code in _LANGUAGE_CODE_TOKEN_PATTERN.findall(path):
         normalized = _normalize_language_token(code)
@@ -588,12 +611,9 @@ def search_books(query: str, filters: SearchFilters) -> list[BrowseRecord]:
     path_language_enabled = _is_language_from_path_enabled()
     requested_langs = _normalize_requested_languages(filters.lang)
 
-    # When path-language inference is enabled, language filtering must happen
-    # after row parsing, otherwise source-side lang filters drop rows too early.
-    if not (path_language_enabled and requested_langs):
-        for value in filters.lang or []:
-            if value and value != "all":
-                filters_query += f"&lang={quote(value)}"
+    for value in filters.lang or []:
+        if value and value != "all":
+            filters_query += f"&lang={quote(value)}"
 
     if filters.sort and filters.sort != "relevance":
         filters_query += f"&sort={quote(filters.sort)}"
@@ -707,7 +727,8 @@ def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
         if not record_id:
             return None
 
-        distant_path = _extract_distant_path(row)
+        path_language_enabled = _is_language_from_path_enabled()
+        distant_path = _extract_distant_path(row, enabled=path_language_enabled)
 
         preview_img = cells[0].find("img")
         preview = _get_attr(preview_img, "src") if isinstance(preview_img, Tag) else None
@@ -724,8 +745,8 @@ def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
         detected_from_path = _detect_language_from_distant_path(distant_path)
 
         # Temporary visual diagnostics for field mapping and path-language inference.
-        if _is_language_from_path_enabled():
-            logger.info(
+        if path_language_enabled:
+            logger.debug(
                 "DD lang debug | id=%s | title=%s | raw_lang=%s | detected_from_path=%s | distant_path=%s | cell11=%s | row=%s",
                 record_id,
                 _short_debug(title),
@@ -736,10 +757,10 @@ def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
                 _short_debug(row.get_text(" ", strip=True), limit=260),
             )
 
-        if _is_language_from_path_enabled() and _is_missing_or_placeholder_language(language):
+        if path_language_enabled and _is_missing_or_placeholder_language(language):
             language = detected_from_path or "unknown"
 
-            logger.info(
+            logger.debug(
                 "DD lang debug resolved | id=%s | final_lang=%s | fallback=%s",
                 record_id,
                 _short_debug(language),

--- a/tests/config/test_download_settings.py
+++ b/tests/config/test_download_settings.py
@@ -368,6 +368,20 @@ def test_download_source_settings_include_direct_download_toggle():
     assert "Add your own mirror URLs" in toggle_field.description
 
 
+def test_download_source_settings_include_distant_path_language_toggle():
+    from shelfmark.config.settings import download_source_settings
+
+    fields = download_source_settings()
+    toggle_field = next(
+        field
+        for field in fields
+        if getattr(field, "key", None) == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH"
+    )
+
+    assert toggle_field.default is False
+    assert "distant path" in toggle_field.description.lower()
+
+
 def test_fast_source_options_lock_entries_without_mirror_or_donator_requirements(monkeypatch):
     from shelfmark.config.settings import _get_fast_source_options
 

--- a/tests/direct_download/test_search_queries.py
+++ b/tests/direct_download/test_search_queries.py
@@ -516,7 +516,9 @@ def test_search_books_filters_language_locally_when_path_language_enabled(monkey
 
     records = dd.search_books("demo", SearchFilters(lang=["fr"], format=["pdf"]))
 
-    assert "&lang=fr" in captured_url["url"]
+    # Server-side &lang= must be suppressed so lgli files without AA language
+    # metadata are not dropped before we can infer the language from the path.
+    assert "&lang=" not in captured_url["url"]
     assert len(records) == 1
     assert records[0].id == "record-fr"
     assert records[0].language == "fr"
@@ -600,7 +602,8 @@ def test_parse_search_result_row_sets_unknown_when_path_language_not_detected(mo
     assert record.language == "unknown"
 
 
-def test_parse_search_result_row_keeps_legacy_behavior_when_toggle_disabled(monkeypatch):
+def test_parse_search_result_row_keeps_row_when_language_missing_and_toggle_disabled(monkeypatch):
+    """Rows with no language metadata should be kept even when path-language is off."""
     from bs4 import BeautifulSoup
 
     import shelfmark.release_sources.direct_download as dd
@@ -635,4 +638,62 @@ def test_parse_search_result_row_keeps_legacy_behavior_when_toggle_disabled(monk
 
     record = dd._parse_search_result_row(row)
 
-    assert record is None
+    assert record is not None
+    assert record.language is None
+
+
+def test_parse_search_result_row_keeps_sparse_lgli_row(monkeypatch):
+    """lgli rows with missing author/publisher/year must not be silently dropped."""
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    # Simulates a real lgli row: author/publisher/year/language cells are empty.
+    html = r"""
+    <tr>
+      <td><a href="/md5/sparse-1"><img src="cover.jpg"></a></td>
+      <td><span>Gos - 1978 - Le scrameustache T06 La fugue du Scrameustache.cbz</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span>Comic book</span></td>
+      <td><span>cbz</span></td>
+      <td><span>17.4MB</span></td>
+      <td><span>lgli/N:\comics1\ftp\[BD.FR] French Comics\Gos\Gos - 1978 - Le scrameustache T06 La fugue du Scrameustache.cbz</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is not None
+    assert record.id == "sparse-1"
+    assert record.format == "cbz"
+    # [BD.FR] in path should be detected as French
+    assert record.language == "fr"
+    assert record.author is None
+    assert record.publisher is None
+    assert record.year is None
+
+
+def test_book_matches_requested_languages_accepts_none_language():
+    """Books returned by the server-side lang filter with no language metadata should pass."""
+    import shelfmark.release_sources.direct_download as dd
+
+    assert dd._book_matches_requested_languages(None, {"fr"}) is True
+    assert dd._book_matches_requested_languages(None, set()) is True
+    assert dd._book_matches_requested_languages("en", {"fr"}) is False
+    assert dd._book_matches_requested_languages("fr", {"fr"}) is True

--- a/tests/direct_download/test_search_queries.py
+++ b/tests/direct_download/test_search_queries.py
@@ -182,3 +182,418 @@ class TestDirectDownloadSearchQueries:
             ("mistborn custom query", ["en"], ["epub"]),
             ("mistborn custom query", None, ["epub"]),
         ]
+
+
+def test_parse_search_result_row_detects_language_from_distant_path(monkeypatch):
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    html = r"""
+    <tr>
+      <td><a href="/md5/record-1"><img src="cover.jpg"></a></td>
+      <td><span>A Book Title</span></td>
+      <td><span>Author Name</span></td>
+      <td><span>Publisher</span></td>
+      <td><span>2024</span></td>
+      <td><span>-</span></td>
+      <td><span>-</span></td>
+      <td></td>
+      <td><span>fiction</span></td>
+      <td><span>epub</span></td>
+      <td><span>1 mb</span></td>
+      <td><span>lgli/N:\comics1\emule\2021.08.01\[BD FR] Scrameustache.cbz</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is not None
+    assert record.language == "fr"
+    assert record.download_path == "lgli/N:\\comics1\\emule\\2021.08.01\\[BD FR] Scrameustache.cbz"
+
+
+def test_parse_search_result_row_detects_mixed_case_language_from_distant_path(monkeypatch):
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    html = r"""
+    <tr>
+      <td><a href="/md5/record-mixed"><img src="cover.jpg"></a></td>
+      <td><span>A Book Title</span></td>
+      <td><span>Author Name</span></td>
+      <td><span>Publisher</span></td>
+      <td><span>2024</span></td>
+      <td><span>-</span></td>
+      <td><span>-</span></td>
+      <td></td>
+      <td><span>fiction</span></td>
+      <td><span>pdf</span></td>
+      <td><span>1 mb</span></td>
+      <td><span>lgli/V:\comics\_0DAY3\[Fr]\BDs [Fr]\!Pdf\S\Scrameustache\Tome 04 - Le totem de l'espace.pdf</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is not None
+    assert record.language == "fr"
+
+
+def test_parse_search_result_row_overrides_unknown_with_distant_path_language(monkeypatch):
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    html = r"""
+    <tr>
+      <td><a href="/md5/record-unknown"><img src="cover.jpg"></a></td>
+      <td><span>A Book Title</span></td>
+      <td><span>Author Name</span></td>
+      <td><span>Publisher</span></td>
+      <td><span>2024</span></td>
+      <td><span>-</span></td>
+      <td><span>-</span></td>
+      <td><span>unknown</span></td>
+      <td><span>fiction</span></td>
+      <td><span>pdf</span></td>
+      <td><span>1 mb</span></td>
+      <td><span>lgli/V:\comics\_0DAY3\[Fr]\BDs [Fr]\!Pdf\S\Scrameustache\Tome 04 - Le totem de l'espace.pdf</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is not None
+    assert record.language == "fr"
+
+
+def test_extract_distant_path_accepts_forward_slash_after_drive(monkeypatch):
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    html = r"""
+    <tr>
+      <td><a href="/md5/record-fslash"><img src="cover.jpg"></a></td>
+      <td><span>A Book Title</span></td>
+      <td><span>Author Name</span></td>
+      <td><span>Publisher</span></td>
+      <td><span>2024</span></td>
+      <td><span>-</span></td>
+      <td><span>-</span></td>
+      <td></td>
+      <td><span>fiction</span></td>
+      <td><span>pdf</span></td>
+      <td><span>1 mb</span></td>
+      <td><span>lgli/V:/comics/_0DAY3/[Fr]/BDs [Fr]/!Pdf/S/Scrameustache/Tome 04 - Le totem de l'espace.pdf</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is not None
+    assert record.language == "fr"
+
+
+def test_parse_search_result_row_detects_language_from_spaced_distant_path(monkeypatch):
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    html = r"""
+    <tr>
+      <td><a href="/md5/record-spaced"><img src="cover.jpg"></a></td>
+      <td><span>Le totem de l'espace</span></td>
+      <td><span>Gos</span></td>
+      <td><span>Dupuis</span></td>
+      <td><span>1977</span></td>
+      <td><span>-</span></td>
+      <td><span>-</span></td>
+      <td></td>
+      <td><span>Comic book</span></td>
+      <td><span>pdf</span></td>
+      <td><span>39.7MB</span></td>
+      <td><span>lgli /V: \comics \ _0DAY3 \[Fr] \BDs [Fr] \!Pdf \S \Scrameustache \Tome 04 - Le totem de l'espace .pdf</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is not None
+    assert record.download_path is not None
+    assert record.language == "fr"
+
+
+def test_parse_search_result_row_avoids_de_false_positive_from_french_sentence(monkeypatch):
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    html = r"""
+    <tr>
+      <td><a href="/md5/record-de-fp"><img src="cover.jpg"></a></td>
+      <td><span>Le totem de l'espace</span></td>
+      <td><span>Gos</span></td>
+      <td><span>Dupuis</span></td>
+      <td><span>1977</span></td>
+      <td><span>-</span></td>
+      <td><span>-</span></td>
+      <td></td>
+      <td><span>Comic book</span></td>
+      <td><span>cbr</span></td>
+      <td><span>40.6MB</span></td>
+      <td><span>lgli/V:\comics\_NON _ENG _ORIG\BDtheque\BD Franco - Belge\S\Scrameustache (le)\Scrameustache (le) - T04 - Le Totem De L'espace [bdc - Jeunesse - Fr].cbr</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is not None
+    assert record.language == "fr"
+
+
+def test_parse_search_result_row_avoids_en_false_positive_when_french_is_present(monkeypatch):
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    html = r"""
+    <tr>
+      <td><a href="/md5/record-en-fp"><img src="cover.jpg"></a></td>
+      <td><span>Le totem de l'espace</span></td>
+      <td><span>Gos</span></td>
+      <td><span>Dupuis</span></td>
+      <td><span>1977</span></td>
+      <td><span>-</span></td>
+      <td><span>-</span></td>
+      <td></td>
+      <td><span>Comic book</span></td>
+      <td><span>cbr</span></td>
+      <td><span>40.6MB</span></td>
+      <td><span>lgli/V:\comics\_0DAY2\Stripboeken Frans - Comix in French - BD en Français\Le Scrameustache\[BD Fr] Le Scrameustache - 04 - Le Totem De L'Espace.cbr</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is not None
+    assert record.language == "fr"
+
+
+def test_search_books_filters_language_locally_when_path_language_enabled(monkeypatch):
+        import shelfmark.release_sources.direct_download as dd
+
+        captured_url: dict[str, str] = {}
+
+        original_get = dd.config.get
+
+        def _fake_get(key: str, default=None, user_id=None):
+                del user_id
+                if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+                        return True
+                return original_get(key, default)
+
+        monkeypatch.setattr(dd.config, "get", _fake_get)
+        monkeypatch.setattr(dd.network, "get_aa_base_url", lambda: "https://mirror.example")
+        monkeypatch.setattr(dd.network, "AAMirrorSelector", lambda: object())
+
+        def _fake_html_get_page(url: str, selector, allow_bypasser_fallback=False):
+                del selector, allow_bypasser_fallback
+                captured_url["url"] = url
+                return r"""
+                <table>
+                    <tr>
+                        <td><a href="/md5/record-fr"><img src="cover.jpg"></a></td>
+                        <td><span>Livre FR</span></td>
+                        <td><span>Auteur</span></td>
+                        <td><span>Editeur</span></td>
+                        <td><span>2025</span></td>
+                        <td><span>-</span></td>
+                        <td><span>-</span></td>
+                        <td></td>
+                        <td><span>fiction</span></td>
+                        <td><span>pdf</span></td>
+                        <td><span>2 mb</span></td>
+                        <td><span>lgli/V:\comics\_0DAY3\[Fr]\BDs [Fr]\!Pdf\S\Book FR.pdf</span></td>
+                    </tr>
+                    <tr>
+                        <td><a href="/md5/record-en"><img src="cover.jpg"></a></td>
+                        <td><span>Book EN</span></td>
+                        <td><span>Author</span></td>
+                        <td><span>Publisher</span></td>
+                        <td><span>2025</span></td>
+                        <td><span>-</span></td>
+                        <td><span>-</span></td>
+                        <td></td>
+                        <td><span>fiction</span></td>
+                        <td><span>pdf</span></td>
+                        <td><span>2 mb</span></td>
+                        <td><span>lgli/V:\comics\_0DAY3\[En]\Comics\!Pdf\S\Book EN.pdf</span></td>
+                    </tr>
+                </table>
+                """
+
+        monkeypatch.setattr(dd.downloader, "html_get_page", _fake_html_get_page)
+
+        records = dd.search_books("demo", SearchFilters(lang=["fr"], format=["pdf"]))
+
+        assert "&lang=" not in captured_url["url"]
+        assert len(records) == 1
+        assert records[0].id == "record-fr"
+        assert records[0].language == "fr"
+
+
+def test_parse_search_result_row_sets_unknown_when_path_language_not_detected(monkeypatch):
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    html = r"""
+    <tr>
+      <td><a href="/md5/record-2"><img src="cover.jpg"></a></td>
+      <td><span>A Book Title</span></td>
+      <td><span>Author Name</span></td>
+      <td><span>Publisher</span></td>
+      <td><span>2024</span></td>
+      <td><span>-</span></td>
+      <td><span>-</span></td>
+      <td></td>
+      <td><span>fiction</span></td>
+      <td><span>epub</span></td>
+      <td><span>1 mb</span></td>
+      <td><span>lgli/N:\comics1\emule\2021.08.01\Scrameustache.cbz</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is not None
+    assert record.language == "unknown"
+
+
+def test_parse_search_result_row_keeps_legacy_behavior_when_toggle_disabled(monkeypatch):
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return False
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    html = r"""
+    <tr>
+      <td><a href="/md5/record-3"><img src="cover.jpg"></a></td>
+      <td><span>A Book Title</span></td>
+      <td><span>Author Name</span></td>
+      <td><span>Publisher</span></td>
+      <td><span>2024</span></td>
+      <td><span>-</span></td>
+      <td><span>-</span></td>
+      <td></td>
+      <td><span>fiction</span></td>
+      <td><span>epub</span></td>
+      <td><span>1 mb</span></td>
+      <td><span>lgli/N:\comics1\emule\2021.08.01\[BD FR] Scrameustache.cbz</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is None

--- a/tests/direct_download/test_search_queries.py
+++ b/tests/direct_download/test_search_queries.py
@@ -460,66 +460,105 @@ def test_parse_search_result_row_avoids_en_false_positive_when_french_is_present
 
 
 def test_search_books_filters_language_locally_when_path_language_enabled(monkeypatch):
-        import shelfmark.release_sources.direct_download as dd
+    import shelfmark.release_sources.direct_download as dd
 
-        captured_url: dict[str, str] = {}
+    captured_url: dict[str, str] = {}
 
-        original_get = dd.config.get
+    original_get = dd.config.get
 
-        def _fake_get(key: str, default=None, user_id=None):
-                del user_id
-                if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
-                        return True
-                return original_get(key, default)
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
 
-        monkeypatch.setattr(dd.config, "get", _fake_get)
-        monkeypatch.setattr(dd.network, "get_aa_base_url", lambda: "https://mirror.example")
-        monkeypatch.setattr(dd.network, "AAMirrorSelector", lambda: object())
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+    monkeypatch.setattr(dd.network, "get_aa_base_url", lambda: "https://mirror.example")
+    monkeypatch.setattr(dd.network, "AAMirrorSelector", lambda: object())
 
-        def _fake_html_get_page(url: str, selector, allow_bypasser_fallback=False):
-                del selector, allow_bypasser_fallback
-                captured_url["url"] = url
-                return r"""
-                <table>
-                    <tr>
-                        <td><a href="/md5/record-fr"><img src="cover.jpg"></a></td>
-                        <td><span>Livre FR</span></td>
-                        <td><span>Auteur</span></td>
-                        <td><span>Editeur</span></td>
-                        <td><span>2025</span></td>
-                        <td><span>-</span></td>
-                        <td><span>-</span></td>
-                        <td></td>
-                        <td><span>fiction</span></td>
-                        <td><span>pdf</span></td>
-                        <td><span>2 mb</span></td>
-                        <td><span>lgli/V:\comics\_0DAY3\[Fr]\BDs [Fr]\!Pdf\S\Book FR.pdf</span></td>
-                    </tr>
-                    <tr>
-                        <td><a href="/md5/record-en"><img src="cover.jpg"></a></td>
-                        <td><span>Book EN</span></td>
-                        <td><span>Author</span></td>
-                        <td><span>Publisher</span></td>
-                        <td><span>2025</span></td>
-                        <td><span>-</span></td>
-                        <td><span>-</span></td>
-                        <td></td>
-                        <td><span>fiction</span></td>
-                        <td><span>pdf</span></td>
-                        <td><span>2 mb</span></td>
-                        <td><span>lgli/V:\comics\_0DAY3\[En]\Comics\!Pdf\S\Book EN.pdf</span></td>
-                    </tr>
-                </table>
-                """
+    def _fake_html_get_page(url: str, selector, allow_bypasser_fallback=False):
+        del selector, allow_bypasser_fallback
+        captured_url["url"] = url
+        return r"""
+        <table>
+            <tr>
+                <td><a href="/md5/record-fr"><img src="cover.jpg"></a></td>
+                <td><span>Livre FR</span></td>
+                <td><span>Auteur</span></td>
+                <td><span>Editeur</span></td>
+                <td><span>2025</span></td>
+                <td><span>-</span></td>
+                <td><span>-</span></td>
+                <td></td>
+                <td><span>fiction</span></td>
+                <td><span>pdf</span></td>
+                <td><span>2 mb</span></td>
+                <td><span>lgli/V:\comics\_0DAY3\[Fr]\BDs [Fr]\!Pdf\S\Book FR.pdf</span></td>
+            </tr>
+            <tr>
+                <td><a href="/md5/record-en"><img src="cover.jpg"></a></td>
+                <td><span>Book EN</span></td>
+                <td><span>Author</span></td>
+                <td><span>Publisher</span></td>
+                <td><span>2025</span></td>
+                <td><span>-</span></td>
+                <td><span>-</span></td>
+                <td></td>
+                <td><span>fiction</span></td>
+                <td><span>pdf</span></td>
+                <td><span>2 mb</span></td>
+                <td><span>lgli/V:\comics\_0DAY3\[En]\Comics\!Pdf\S\Book EN.pdf</span></td>
+            </tr>
+        </table>
+        """
 
-        monkeypatch.setattr(dd.downloader, "html_get_page", _fake_html_get_page)
+    monkeypatch.setattr(dd.downloader, "html_get_page", _fake_html_get_page)
 
-        records = dd.search_books("demo", SearchFilters(lang=["fr"], format=["pdf"]))
+    records = dd.search_books("demo", SearchFilters(lang=["fr"], format=["pdf"]))
 
-        assert "&lang=" not in captured_url["url"]
-        assert len(records) == 1
-        assert records[0].id == "record-fr"
-        assert records[0].language == "fr"
+    assert "&lang=fr" in captured_url["url"]
+    assert len(records) == 1
+    assert records[0].id == "record-fr"
+    assert records[0].language == "fr"
+
+
+def test_parse_search_result_row_prefers_non_ambiguous_bracketed_language(monkeypatch):
+    from bs4 import BeautifulSoup
+
+    import shelfmark.release_sources.direct_download as dd
+
+    original_get = dd.config.get
+
+    def _fake_get(key: str, default=None, user_id=None):
+        del user_id
+        if key == "DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH":
+            return True
+        return original_get(key, default)
+
+    monkeypatch.setattr(dd.config, "get", _fake_get)
+
+    html = r"""
+    <tr>
+      <td><a href="/md5/record-en-first"><img src="cover.jpg"></a></td>
+      <td><span>Le totem de l'espace</span></td>
+      <td><span>Gos</span></td>
+      <td><span>Dupuis</span></td>
+      <td><span>1977</span></td>
+      <td><span>-</span></td>
+      <td><span>-</span></td>
+      <td></td>
+      <td><span>Comic book</span></td>
+      <td><span>cbr</span></td>
+      <td><span>40.6MB</span></td>
+      <td><span>lgli/V:\comics\_0DAY2\[EN]\Stripboeken Frans - Comix in French\Le Scrameustache\[BD Fr] Le Scrameustache - 04 - Le Totem De L'Espace.cbr</span></td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+
+    record = dd._parse_search_result_row(row)
+
+    assert record is not None
+    assert record.language == "fr"
 
 
 def test_parse_search_result_row_sets_unknown_when_path_language_not_detected(monkeypatch):


### PR DESCRIPTION
- Added language detection throught the distant path of AA.
- Added option in setting to disable this feature.

This is to avoid shelfmark dumping many result due to missing language in AA. 
With this option enabled, it will parse the distant path (don’t know how its named) to look for language and set the language accordingly.

I tested it with different request and language and the parsing seem ok to me but it can probably be improved.
The option can be enabled or disabled in the setting Direct Download > Download Source