### PR TITLE
Add custom source plugin system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,5 @@ AGENTS.md
 .playwright-mcp/
 frontend-dist/
 node_modules/
+
+/data/

--- a/docs/custom-sources.md
+++ b/docs/custom-sources.md
@@ -1,0 +1,44 @@
+# Custom Sources
+
+Custom sources let you add new book search and download sources to Shelfmark without modifying Shelfmark's own code. Each custom source is a single Python script that you drop into your config directory.
+
+## How it works
+
+Shelfmark scans for `.py` files in `$CONFIG_DIR/custom_sources/` every time it starts. Any file it finds is loaded automatically and appears under **Settings → Custom Sources**.
+
+`$CONFIG_DIR` is wherever you mounted the Shelfmark config volume — typically `./data/config/` in a Docker Compose setup.
+
+> **Why isn't `data/` in git?**  
+> The `data/` directory is a runtime volume: it holds your database, saved settings, API keys, and downloaded files. It belongs on your machine, not in the source tree. Custom source plugins live there too, which is fine — they're personal to your instance. The example and reference files in `docs/` are what gets shared via git.
+
+## Adding a plugin
+
+1. Copy `docs/example_custom_source.py` to `$CONFIG_DIR/custom_sources/my_source.py`
+2. Edit it to point at your actual source
+3. Restart Shelfmark — your source appears under Custom Sources in Settings
+
+Each plugin gets its own settings tab automatically, containing at minimum an **Enable / Disable** toggle. You can turn a plugin off without deleting the file.
+
+## Dependencies
+
+If your plugin needs a Python library that isn't already included (e.g. `beautifulsoup4`, `lxml`), create a `requirements.txt` in the same folder:
+
+```
+$CONFIG_DIR/custom_sources/requirements.txt
+```
+
+List one package per line. Shelfmark runs `pip install -r requirements.txt` automatically the next time it starts. The `requests` library is always available without adding it.
+
+## Security
+
+> ⚠ **Plugin files run as full Python code** with the same access as Shelfmark itself — they can read your config, access the network, and write files. Only install plugins from sources you trust. Treat them the same as any program you run on your machine.
+
+## Reference files
+
+| File | Purpose |
+|------|---------|
+| `docs/example_custom_source.py` | Template to copy and edit — covers every feature with inline comments |
+
+## Developer reference
+
+For the complete API — all classes, callbacks, field types, column config, and download protocols — see the [Release Sources Plugin Guide](dev/release-sources-plugin-guide.md).

--- a/docs/example_custom_source.py
+++ b/docs/example_custom_source.py
@@ -1,0 +1,488 @@
+"""
+Example custom source plugin for Shelfmark.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  HOW TO USE THIS FILE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Copy this file to:   $CONFIG_DIR/custom_sources/my_source.py
+2. Edit it to point at your actual source.
+3. Restart Shelfmark — your source appears in Settings > Custom Sources.
+
+$CONFIG_DIR is wherever you mounted the Shelfmark config volume, e.g.
+  ./data/config/  (Docker Compose default)
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  DEPENDENCIES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+If your plugin needs a third-party library (e.g. beautifulsoup4, lxml),
+create a requirements.txt in the same folder:
+
+  $CONFIG_DIR/custom_sources/requirements.txt
+
+Shelfmark installs those packages automatically at startup.
+The `requests` library is always available without adding it.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ⚠ SECURITY
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Plugin files run as full Python code with the same access as Shelfmark
+itself. Only install plugins from sources you trust — treat them the
+same as any program you run on your machine.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WHAT A PLUGIN MUST PROVIDE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  @register_source("your_name")   → ReleaseSource subclass  (search)
+  @register_handler("your_name")  → DownloadHandler subclass (download)
+
+The name must be unique and must not clash with built-ins:
+  direct_download, prowlarr, newznab, irc, audiobookbay
+
+Everything else in this file is optional — remove what you don't need.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  DOWNLOAD PROTOCOLS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Three download styles are supported:
+
+  HTTP    — your handler downloads directly to a temp file (default)
+  TORRENT — your handler hands a magnet/torrent URL to qBittorrent etc.
+  NZB     — your handler hands an NZB URL to SABnzbd/NZBGet etc.
+
+For torrent and NZB, use ExternalClientHandler (see the bottom of
+this file) instead of writing download logic yourself.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  AUDIOBOOK ROUTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Set content_type="audiobook" on your Release objects and Shelfmark
+automatically routes downloads to the audiobook destination folder.
+Set content_type="ebook" (or leave blank) for regular books.
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import requests
+
+from shelfmark.release_sources import (
+    DownloadHandler,
+    Release,
+    ReleaseColumnConfig,
+    ReleaseProtocol,
+    ReleaseSource,
+    SourceUnavailableError,
+    register_handler,
+    register_source,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from threading import Event
+
+    from shelfmark.core.models import DownloadTask
+    from shelfmark.core.search_plan import ReleaseSearchPlan
+    from shelfmark.metadata_providers import BookMetadata
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Identity — pick a short stable name and never change it.
+# It is stored in the database against every download from this source.
+# ─────────────────────────────────────────────────────────────────────────────
+SOURCE_NAME = "my_private_tracker"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1.  ReleaseSource  —  responsible for SEARCHING
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@register_source(SOURCE_NAME)
+class MyTrackerSource(ReleaseSource):
+    name = SOURCE_NAME
+    display_name = "My Private Tracker"
+
+    # Which content types this source supports.
+    # Remove "audiobook" or "ebook" if your source only carries one type.
+    supported_content_types: list[str] = ["ebook", "audiobook"]  # noqa: RUF012
+
+    # Set False to hide this source from the "Default Release Source" dropdown.
+    # Leave True for most sources.
+    can_be_default: bool = True
+
+    def is_available(self) -> bool:
+        """Return True only when the source is properly configured and usable."""
+        from shelfmark.core.config import config
+
+        return bool(config.get("MY_TRACKER_URL", "") and config.get("MY_TRACKER_API_KEY", ""))
+
+    def search(
+        self,
+        book: BookMetadata,
+        plan: ReleaseSearchPlan,
+        *,
+        expand_search: bool = False,
+        content_type: str = "ebook",
+    ) -> list[Release]:
+        if not self.is_available():
+            raise SourceUnavailableError(f"{self.display_name} is not configured")
+
+        from shelfmark.core.config import config
+
+        base_url = config.get("MY_TRACKER_URL", "") or ""
+        api_key = config.get("MY_TRACKER_API_KEY", "") or ""
+
+        query = book.search_title or book.title
+        if book.search_author:
+            query = f"{query} {book.search_author}"
+
+        try:
+            resp = requests.get(
+                f"{base_url}/api/search",
+                params={"q": query, "key": api_key, "type": content_type},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            results = resp.json().get("results", [])
+        except requests.RequestException as exc:
+            raise SourceUnavailableError(f"{self.display_name} search failed: {exc}") from exc
+
+        releases: list[Release] = []
+        for item in results:
+            releases.append(  # noqa: PERF401
+                Release(
+                    source=SOURCE_NAME,
+                    source_id=str(item["id"]),
+                    title=item.get("title", ""),
+                    format=item.get("format"),  # "epub", "pdf", "mp3", …
+                    language=item.get("language"),  # ISO 639-1 code: "en", "de", …
+                    size=item.get("size_human"),  # human-readable: "12 MB"
+                    size_bytes=item.get("size_bytes"),
+                    download_url=item.get("download_url"),
+                    info_url=item.get("page_url"),  # makes the title a clickable link
+                    protocol=ReleaseProtocol.HTTP,  # or TORRENT / NZB — see bottom
+                    indexer=self.display_name,
+                    content_type=content_type,  # "ebook" or "audiobook" — drives destination routing
+                    extra={},
+                )
+            )
+        return releases
+
+    # ── Optional: customise the columns shown in the release list ──────────
+    # Delete this method to use the default layout (language / format / size).
+
+    def get_column_config(self) -> ReleaseColumnConfig:
+        from shelfmark.release_sources import (
+            ColumnAlign,
+            ColumnColorHint,
+            ColumnRenderType,
+            ColumnSchema,
+        )
+
+        return ReleaseColumnConfig(
+            columns=[
+                ColumnSchema(
+                    key="language",
+                    label="Language",
+                    render_type=ColumnRenderType.BADGE,
+                    align=ColumnAlign.CENTER,
+                    width="60px",
+                    color_hint=ColumnColorHint(type="map", value="language"),
+                    uppercase=True,
+                ),
+                ColumnSchema(
+                    key="format",
+                    label="Format",
+                    render_type=ColumnRenderType.BADGE,
+                    align=ColumnAlign.CENTER,
+                    width="80px",
+                    color_hint=ColumnColorHint(type="map", value="format"),
+                    uppercase=True,
+                ),
+                ColumnSchema(
+                    key="size",
+                    label="Size",
+                    render_type=ColumnRenderType.SIZE,
+                    align=ColumnAlign.CENTER,
+                    width="80px",
+                ),
+            ],
+            grid_template="minmax(0,2fr) 60px 80px 80px",
+            supported_filters=["format", "language"],
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2.  DownloadHandler  —  responsible for DOWNLOADING (HTTP version)
+#
+#     Use this style when you fetch the file directly.
+#     For torrent / NZB hand-off, see the ExternalClientHandler section below.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@register_handler(SOURCE_NAME)
+class MyTrackerHandler(DownloadHandler):
+    def download(
+        self,
+        task: DownloadTask,
+        cancel_flag: Event,
+        progress_callback: Callable[[float], None],
+        status_callback: Callable[[str, str | None], None],
+    ) -> str | None:
+        """
+        Download the file and return its local path, or None if cancelled.
+
+        ── YOU must drive the status label ──────────────────────────
+        Shelfmark starts every download as "pending" and waits for you.
+        If you never call status_callback, the queue shows "pending"
+        the whole time — even while the file is actually downloading.
+
+        Call it at least twice during a typical download:
+          status_callback("resolving", "Connecting…")  # before any network call
+          status_callback("downloading", None)          # once bytes start flowing
+
+        Valid values: "resolving", "downloading"
+        Do NOT call "complete", "failed", or "cancelled" — those are set
+        automatically by Shelfmark when your method returns or raises.
+
+        ── YOU must drive the progress bar ──────────────────────────
+        progress_callback(0–100) moves the bar. Call it inside your
+        download loop — the bar stays at 0 if you never call it.
+        If the server doesn't send a content-length, estimate:
+          progress_callback(min(downloaded / 500_000 * 80, 90))
+          progress_callback(100)  # always finish at 100
+
+        ── task fields ───────────────────────────────────────────────
+          task.task_id    — source_id from the Release (e.g. a book ID or GUID)
+          task.source_url — download_url from the Release
+          task.title      — display title
+          task.author     — author name (may be None)
+          task.format     — file format (may be None)
+
+        ── cancel_flag ───────────────────────────────────────────────
+        Check cancel_flag.is_set() inside every loop. Delete partial
+        files and return None. None = cancelled cleanly (not failed).
+
+        ── error messages ────────────────────────────────────────────
+        Any exception message is shown in the failed-download UI, so
+        make it descriptive:
+          raise RuntimeError("No file found for this book")
+          raise RuntimeError(f"Tracker returned 403 — check your API key")
+
+        ── return value ──────────────────────────────────────────────
+        Return the local path to the downloaded file (string or Path).
+        Shelfmark handles everything after: moving to the library,
+        extraction, notifications, and history recording.
+        """
+        from shelfmark.config.env import TMP_DIR
+
+        if not task.source_url:
+            msg = "No download URL on task"
+            raise RuntimeError(msg)
+
+        status_callback("resolving", "Contacting tracker…")
+
+        from shelfmark.core.config import config
+
+        base_url = config.get("MY_TRACKER_URL", "") or ""
+        api_key = config.get("MY_TRACKER_API_KEY", "") or ""
+
+        # Optional: resolve a signed/temporary URL before downloading.
+        # If your URLs don't expire, skip this block and use task.source_url directly.
+        try:
+            resp = requests.get(
+                f"{base_url}/api/resolve/{task.task_id}",
+                params={"key": api_key},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            url = resp.json().get("url", task.source_url)
+        except requests.RequestException:
+            url = task.source_url  # fall back to the URL on the task
+
+        status_callback("downloading", None)
+
+        dest = TMP_DIR / f"{task.task_id}.tmp"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            with requests.get(url, stream=True, timeout=60) as r:
+                r.raise_for_status()
+                total = int(r.headers.get("content-length", 0))
+                downloaded = 0
+                with dest.open("wb") as fh:
+                    for chunk in r.iter_content(chunk_size=65536):
+                        if cancel_flag.is_set():
+                            dest.unlink(missing_ok=True)
+                            return None
+                        fh.write(chunk)
+                        downloaded += len(chunk)
+                        if total:
+                            progress_callback(downloaded / total * 100)
+        except requests.RequestException as exc:
+            dest.unlink(missing_ok=True)
+            raise RuntimeError(f"Download failed: {exc}") from exc
+
+        return str(dest)
+
+    def cancel(self, task_id: str) -> bool:
+        # cancel_flag in download() handles cancellation; nothing extra needed here.
+        return True
+
+    # ── Optional: support restart-safe retry for expiring URLs ────────────
+    # If your download URLs expire (e.g. signed S3 links), override this method.
+    # Shelfmark calls it at queue time and stores the result so it can re-resolve
+    # the URL if a download is interrupted and needs to restart.
+    #
+    # def build_retry_resolution_fields(self, release_data: dict) -> dict:
+    #     return {
+    #         "retry_download_url": release_data.get("download_url"),
+    #         "retry_download_protocol": "http",
+    #     }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3.  Settings fields  —  OPTIONAL
+#
+#     Shelfmark always creates a settings tab for your plugin containing at
+#     minimum an Enable/Disable toggle. Define get_settings_fields() to add
+#     extra fields below it — URLs, API keys, checkboxes, etc.
+#
+#     Values are stored in $CONFIG_DIR/plugins/custom_<filename>.json
+#     and readable anywhere via:
+#       from shelfmark.core.config import config
+#       config.get("MY_KEY", "default_value")
+#
+#     ⚠ IMPORTANT: field keys are GLOBAL across all plugins. Two plugins
+#     both using key="API_KEY" will share one config slot and overwrite each
+#     other. Always prefix your keys with a unique source identifier:
+#       key="MY_TRACKER_API_KEY"  ✓
+#       key="API_KEY"             ✗ (conflicts with any other plugin using API_KEY)
+#
+#     Also: do NOT call config.get() inside get_settings_fields(). This function
+#     defines the field schema only — current values are loaded by Shelfmark.
+#     Calling config.get() here during startup can cause a deadlock.
+#
+#     ActionButton: when clicked, Shelfmark runs the callback server-side.
+#     The function must return {"success": True/False, "message": "..."}.
+#     The message is shown as a green (success) or red (failure) notice.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def get_settings_fields() -> list:
+    """Return extra settings fields shown under this source's settings tab."""
+    from shelfmark.core.settings_registry import (
+        ActionButton,
+        CheckboxField,
+        PasswordField,
+        TextField,
+    )
+
+    return [
+        TextField(
+            key="MY_TRACKER_URL",
+            label="Tracker URL",
+            description="Base URL of your tracker (e.g. https://tracker.example.com)",
+            placeholder="https://tracker.example.com",
+            default="",
+        ),
+        PasswordField(
+            key="MY_TRACKER_API_KEY",
+            label="API Key",
+            description="Your tracker API key. Stored securely and never shown in the UI again.",
+            placeholder="paste your key here",
+            default="",
+        ),
+        CheckboxField(
+            key="MY_TRACKER_PREFER_EPUB",
+            label="Prefer EPUB",
+            description="Download EPUB when both EPUB and PDF are available.",
+            default=True,
+        ),
+        # Optional: add a test-connection button.
+        # The callback runs server-side when the user clicks the button.
+        ActionButton(
+            key="MY_TRACKER_TEST",
+            label="Test connection",
+            description="Check that Shelfmark can reach the tracker with the URL and key above.",
+            style="default",
+            callback=_test_tracker_connection,
+        ),
+    ]
+
+
+def _test_tracker_connection() -> dict:
+    """Called when the user clicks the Test Connection button."""
+    from shelfmark.core.config import config
+
+    url = config.get("MY_TRACKER_URL", "")
+    key = config.get("MY_TRACKER_API_KEY", "")
+    if not url or not key:
+        return {"success": False, "message": "URL and API key are required."}
+    try:
+        resp = requests.get(f"{url}/api/ping", params={"key": key}, timeout=10)
+        resp.raise_for_status()
+        return {"success": True, "message": "Connected successfully."}
+    except requests.RequestException as exc:
+        return {"success": False, "message": f"Connection failed: {exc}"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4.  Torrent / NZB hand-off  (alternative to the HTTP handler above)
+#
+#     If your source returns torrents or NZBs, use ExternalClientHandler.
+#     Shelfmark hands the torrent/NZB to whatever download client the user
+#     has configured (qBittorrent, Deluge, SABnzbd, NZBGet, etc.).
+#     You do NOT write a download() method at all — just resolve the URL.
+#
+#     You also do NOT call status_callback or progress_callback.
+#     Shelfmark polls the download client directly for speed and progress
+#     and reports everything to the UI automatically.
+#
+#     To use this: replace MyTrackerHandler above with the class below,
+#     and set protocol=ReleaseProtocol.TORRENT (or NZB) on your Release objects.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# @register_handler(SOURCE_NAME)
+# class MyTrackerTorrentHandler(ExternalClientHandler):
+#
+#     def _resolve_download(self, task, status_callback):
+#         """Return a DownloadRequest describing what to send to the download client."""
+#         from shelfmark.download.clients.base_handler import DownloadRequest
+#
+#         from shelfmark.core.config import config
+#         base_url = config.get("MY_TRACKER_URL", "") or ""
+#         api_key = config.get("MY_TRACKER_API_KEY", "") or ""
+#
+#         status_callback("resolving", "Fetching torrent info…")
+#
+#         try:
+#             resp = requests.get(
+#                 f"{base_url}/api/torrent/{task.task_id}",
+#                 params={"key": api_key},
+#                 timeout=15,
+#             )
+#             resp.raise_for_status()
+#             data = resp.json()
+#         except requests.RequestException as exc:
+#             raise RuntimeError(f"Could not resolve torrent: {exc}") from exc
+#
+#         return DownloadRequest(
+#             url=data["magnet"],           # magnet link or .torrent URL
+#             protocol="torrent",           # "torrent" or "usenet"
+#             release_name=task.title,
+#             expected_hash=data.get("info_hash"),   # optional, for dedup
+#         )
+#
+#     def cancel(self, task_id):
+#         return True
+
+# To use ExternalClientHandler, uncomment the import:
+# from shelfmark.download.clients.base_handler import ExternalClientHandler, DownloadRequest

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Use the guides below to set up the app, connect your library tools, and understa
 ## Core Guides
 
 - [Users & Requests](users-and-requests.md)
+- [Custom Sources](custom-sources.md)
 - [Reverse Proxy](reverse-proxy.md)
 - [OIDC](oidc.md)
 - [URL Search Parameters](url-search-parameters.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,10 @@ select = [
 ignore = ["D", "EM", "FBT", "PLR2004", "UP035", "TRY003", "E501", "TD002", "S104", "S603"]
 
 [tool.ruff.lint.per-file-ignores]
+"docs/**/*.py" = [
+    "ERA001",  # commented-out code blocks are intentional examples
+    "TRY300",
+]
 "scripts/**/*.py" = [
     "BLE001",
     "S",

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,8 @@
 
 <img src="src/frontend/public/logo.png" alt="Shelfmark" width="200">
 
-> [!NOTE]
-> This project is in a stable state as of May 2026 but is not under active maintenance. 
+> [!IMPORTANT]
+> This is an **actively maintained community fork** of [calibrain/shelfmark](https://github.com/calibrain/shelfmark). New features, bug fixes, and improvements are added here. The upstream project is no longer under active maintenance.
 
 Shelfmark is a self-hosted web interface for searching and requesting books and audiobooks across multiple sources. Bring your own sources, metadata providers, and download clients to build a single hub for your digital library. Supports multiple users with a built-in request system, so you can share your instance with others and let them browse and request books on their own.
 

--- a/shelfmark/config/settings.py
+++ b/shelfmark/config/settings.py
@@ -143,6 +143,61 @@ def _log_external_bypasser_warning() -> None:
 
 
 register_group("direct_download", "Direct Download", icon="download", order=20)
+register_group("custom_sources", "Custom Sources", icon="download", order=58)
+
+
+@register_settings(
+    "custom_sources_about", "About Custom Sources", icon="info", order=58, group="custom_sources"
+)
+def _custom_sources_about_fields() -> list:
+    return [
+        HeadingField(
+            key="custom_sources_what_heading",
+            title="What are custom sources?",
+            description=(
+                "Custom sources are Python scripts you place in the custom_sources/ folder "
+                "inside your Shelfmark config directory. Each script adds a new search and "
+                "download source without touching Shelfmark's built-in code."
+            ),
+        ),
+        HeadingField(
+            key="custom_sources_how_heading",
+            title="How to add one",
+            description="Follow these three steps:",
+        ),
+        HeadingField(
+            key="custom_sources_how_step1",
+            title="1.  Drop the plugin file in place",
+            description="Copy your .py plugin file into config/custom_sources/ inside your Shelfmark config folder.",
+        ),
+        HeadingField(
+            key="custom_sources_how_step2",
+            title="2.  Restart Shelfmark",
+            description="Shelfmark picks it up automatically on the next start — it appears here under Custom Sources.",
+        ),
+        HeadingField(
+            key="custom_sources_how_step3",
+            title="3.  Add dependencies (if needed)",
+            description=(
+                "If the plugin uses a library that isn't already built into Shelfmark "
+                "(e.g. beautifulsoup4, lxml), create a file called requirements.txt in the same "
+                "config/custom_sources/ folder and list each package on its own line. "
+                "Shelfmark installs them automatically the next time it starts."
+            ),
+        ),
+        HeadingField(
+            key="custom_sources_security_heading",
+            title="⚠ Security — only install plugins you trust",
+            description=(
+                "Plugin files run as full Python code with the same access as Shelfmark itself — "
+                "they can read your config, access the network, and write files. "
+                "Only install plugins from sources you trust, the same way you would treat "
+                "any program you install on your computer. "
+                "Do not run plugins shared by strangers without reviewing the code first."
+            ),
+        ),
+    ]
+
 
 register_group(
     "metadata_providers",
@@ -1869,3 +1924,31 @@ def advanced_settings() -> list[SettingsField]:
 
 
 register_on_save("advanced", _on_save_advanced)
+
+# Eagerly load custom source plugins here, after all settings.py tabs are
+# registered and _REGISTRY_LOCK is fully released, so custom source tabs are in
+# _SETTINGS_REGISTRY before the first /api/settings snapshot.
+#
+# Without this, the lazy trigger inside serialize_tab() (via the callable
+# _get_book_release_source_options) registers custom tabs AFTER
+# get_all_settings_tabs() has already snapshotted, leaving them absent from the
+# first settings response.
+#
+# Side-effect: importing shelfmark.config.settings now loads custom plugins and
+# may run `pip install -r requirements.txt`. This is intentional — it is startup
+# work that must finish before the app serves requests. It does NOT run on plain
+# `import shelfmark.release_sources`; that import is now side-effect free.
+try:
+    from shelfmark.release_sources import _ensure_builtin_sources_registered as _load_sources
+
+    _load_sources()
+except ImportError:
+    pass  # shelfmark.release_sources unavailable in lightweight test environments
+except Exception as _exc:  # noqa: BLE001
+    import logging as _logging
+
+    _logging.getLogger(__name__).warning(
+        "Custom source startup hook raised %s: %s — custom tabs may be absent",
+        type(_exc).__name__,
+        _exc,
+    )

--- a/shelfmark/download/orchestrator.py
+++ b/shelfmark/download/orchestrator.py
@@ -28,6 +28,7 @@ from shelfmark.download.fs import run_blocking_io
 from shelfmark.download.postprocess.pipeline import is_torrent_source, safe_cleanup_path
 from shelfmark.download.postprocess.router import post_process_download
 from shelfmark.release_sources import (
+    SourceUnavailableError,
     get_handler,
     get_source,
     get_source_display_name,
@@ -110,7 +111,10 @@ def _parse_release_search_mode(value: object) -> SearchMode:
 
 
 def _source_unavailable_message(source_name: str) -> str | None:
-    source = get_source(source_name)
+    try:
+        source = get_source(source_name)
+    except SourceUnavailableError as exc:
+        return str(exc)
     if source.is_available():
         return None
     return f"{source.display_name} is unavailable. Enable and configure the source in Settings."

--- a/shelfmark/download/postprocess/destination.py
+++ b/shelfmark/download/postprocess/destination.py
@@ -14,7 +14,7 @@ from shelfmark.core.utils import (
 )
 from shelfmark.download.fs import run_blocking_io
 from shelfmark.download.permissions_debug import log_path_permission_context
-from shelfmark.release_sources import get_source
+from shelfmark.release_sources import SourceUnavailableError, get_source
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -74,7 +74,7 @@ def get_final_destination(task: DownloadTask) -> Path:
 
     try:
         override = get_source(task.source).get_destination_override(task)
-    except ValueError:
+    except ValueError, SourceUnavailableError:
         override = None
 
     if override:

--- a/shelfmark/main.py
+++ b/shelfmark/main.py
@@ -3134,10 +3134,10 @@ def api_settings_get_tab(tab_name: str) -> Response | tuple[Response, int]:
         # Ensure settings are registered
         import_module("shelfmark.config.settings")
         import_module("shelfmark.config.users_settings")
-        from shelfmark.core.settings_registry import (
-            get_settings_tab,
-            serialize_tab,
-        )
+        from shelfmark.core.settings_registry import get_settings_tab, serialize_tab
+        from shelfmark.release_sources import _apply_deferred_field_updates
+
+        _apply_deferred_field_updates()
 
         tab = get_settings_tab(tab_name)
         if not tab:

--- a/shelfmark/release_sources/__init__.py
+++ b/shelfmark/release_sources/__init__.py
@@ -14,7 +14,10 @@ if TYPE_CHECKING:
     from shelfmark.core.models import DownloadTask
     from shelfmark.core.search_plan import ReleaseSearchPlan
 
+from shelfmark.core.logger import setup_logger
 from shelfmark.metadata_providers import BookMetadata
+
+logger = setup_logger(__name__)
 
 
 class ReleaseProtocol(StrEnum):
@@ -403,6 +406,9 @@ class DownloadHandler(ABC):
 
 _SOURCES: dict[str, type[ReleaseSource]] = {}
 _HANDLERS: dict[str, type[DownloadHandler]] = {}
+# Maps custom source name → config key for its enable toggle (e.g. "my_source" → "CUSTOM_MY_SOURCE_ENABLED")
+# Checked in list_available_sources() before the plugin's own is_available() — plugin has no say.
+_CUSTOM_SOURCE_ENABLE_KEYS: dict[str, str] = {}
 _BUILTIN_SOURCE_MODULES = (
     "shelfmark.release_sources.audiobookbay",
     "shelfmark.release_sources.direct_download",
@@ -411,17 +417,362 @@ _BUILTIN_SOURCE_MODULES = (
     "shelfmark.release_sources.prowlarr",
 )
 _builtin_source_state = {"loaded": False}
+# Plugin field registrations deferred because _cache_lock was held at load time.
+# Applied lazily on the first public API call after startup.
+# key: tab_name ("custom_<stem>")  value: (stem, get_settings_fields callable)
+_deferred_field_updates: dict[str, tuple[str, Any]] = {}
+
+
+def _register_custom_source_settings(
+    stem: str, module: object, source_names: set[str], order: int
+) -> None:
+    """Register a settings tab and enable-key mapping for a loaded custom source plugin."""
+    from shelfmark.core.settings_registry import CheckboxField, HeadingField, register_settings
+
+    # Derive display name from whichever source class the plugin registered.
+    # Read the class attribute directly — no instantiation, so a buggy __init__ can't
+    # throw here and leave the source registered without an enable-key entry.
+    source_cls = next((cls for n, cls in _SOURCES.items() if n in source_names), None)
+    display_name = source_cls.display_name if source_cls else stem.replace("_", " ").title()
+
+    # Stable config key owned entirely by Shelfmark — the plugin never touches it
+    enable_key = f"CUSTOM_{stem.upper()}_ENABLED"
+
+    # Register the enable key for every source name the plugin added.
+    # list_available_sources() checks this dict before the plugin's is_available().
+    for source_name in source_names:
+        _CUSTOM_SOURCE_ENABLE_KEYS[source_name] = enable_key
+
+    get_fields = getattr(module, "get_settings_fields", None)
+
+    # Call get_settings_fields() NOW — before register_settings() — because
+    # register_settings() invokes its argument immediately (see settings_registry.py).
+    # That means any config.get() call inside the plugin would run while
+    # Config._cache_lock is potentially held (we may be inside _load_settings()),
+    # causing a deadlock. Guard with a non-blocking lock acquire: if the lock is
+    # already held by this thread's call stack, skip plugin fields rather than hang.
+    plugin_extra_fields: list = []
+    if callable(get_fields):
+        _config_lock_free = True
+        try:
+            from shelfmark.core.config import config as _cfg
+
+            _lock = getattr(_cfg, "_cache_lock", None)
+            if _lock is not None:
+                _acquired = _lock.acquire(blocking=False)
+                if _acquired:
+                    _lock.release()
+                else:
+                    _config_lock_free = False
+                    _deferred_field_updates[f"custom_{stem}"] = (stem, get_fields)
+                    logger.debug(
+                        "Plugin %s: deferring get_settings_fields() — config lock is held. "
+                        "Fields will be applied on the next source API call.",
+                        stem,
+                    )
+        except Exception:  # noqa: BLE001, S110
+            pass  # if we can't inspect the lock, assume safe; real errors surface below
+
+        if _config_lock_free:
+            try:
+                result = get_fields()
+                if isinstance(result, list):
+                    # Remove fields whose key is already claimed globally OR by the
+                    # Shelfmark-owned fields we always inject into this very tab.
+                    # Field keys are global across all plugins; a plugin using
+                    # CUSTOM_FOO_ENABLED would silently overwrite Shelfmark's own
+                    # enable checkbox unless we guard it here.
+                    from shelfmark.core.settings_registry import get_settings_field_map
+
+                    existing_keys = set(get_settings_field_map().keys())
+                    shelfmark_owned = {f"custom_{stem}_heading", f"CUSTOM_{stem.upper()}_ENABLED"}
+                    reserved = existing_keys | shelfmark_owned
+                    clean: list = []
+                    for field in result:
+                        fkey = getattr(field, "key", None)
+                        if fkey and fkey in reserved:
+                            logger.warning(
+                                "Plugin %s: field key %r conflicts with a reserved key — "
+                                "skipping. Prefix plugin keys e.g. %s_%s.",
+                                stem,
+                                fkey,
+                                stem.upper(),
+                                fkey,
+                            )
+                        else:
+                            clean.append(field)
+                            if fkey:
+                                reserved.add(fkey)  # prevent same-plugin duplicates
+                    plugin_extra_fields = clean
+                else:
+                    logger.warning(
+                        "get_settings_fields() for %s returned %s, expected list — ignored",
+                        stem,
+                        type(result).__name__,
+                    )
+            except Exception:
+                logger.exception("Error calling get_settings_fields() for plugin: %s", stem)
+
+    def _build_fields() -> list:
+        fields: list = [
+            HeadingField(
+                key=f"custom_{stem}_heading",
+                title=display_name,
+                description=f"Loaded from custom_sources/{stem}.py",
+            ),
+            CheckboxField(
+                key=enable_key,
+                label=f"Enable {display_name}",
+                default=True,
+                description=f"Enable or disable the {display_name} source",
+            ),
+        ]
+        fields.extend(plugin_extra_fields)
+        return fields
+
+    register_settings(
+        name=f"custom_{stem}",
+        display_name=display_name,
+        icon="download",
+        order=order,
+        group="custom_sources",
+    )(_build_fields)
+
+
+def _apply_deferred_field_updates() -> None:
+    """Apply plugin settings fields that were skipped because _cache_lock was held at load time.
+
+    Called lazily from the first public source API call after startup so the lock
+    is guaranteed to be free. Idempotent — clears the deferred queue on each run.
+    """
+    if not _deferred_field_updates:
+        return
+
+    from shelfmark.core.config import config as _cfg
+
+    _lock = getattr(_cfg, "_cache_lock", None)
+    if _lock is not None:
+        _acquired = _lock.acquire(blocking=False)
+        if not _acquired:
+            return  # still locked — will retry on the next API call
+        _lock.release()
+
+    from shelfmark.core.settings_registry import (
+        _REGISTRY_LOCK,
+        _SETTINGS_REGISTRY,
+        get_settings_field_map,
+    )
+
+    pending = list(_deferred_field_updates.items())
+    _deferred_field_updates.clear()
+
+    for tab_name, (stem, get_fields_fn) in pending:
+        try:
+            result = get_fields_fn()
+            if not isinstance(result, list):
+                logger.warning(
+                    "Plugin %s deferred get_settings_fields() returned %s — ignored",
+                    stem,
+                    type(result).__name__,
+                )
+                continue
+            existing_keys = set(get_settings_field_map().keys())
+            shelfmark_owned = {f"custom_{stem}_heading", f"CUSTOM_{stem.upper()}_ENABLED"}
+            reserved = existing_keys | shelfmark_owned
+            clean: list = []
+            for field in result:
+                fkey = getattr(field, "key", None)
+                if fkey and fkey in reserved:
+                    logger.warning(
+                        "Plugin %s deferred: field key %r conflicts — skipped", stem, fkey
+                    )
+                else:
+                    clean.append(field)
+                    if fkey:
+                        reserved.add(fkey)
+            if clean:
+                with _REGISTRY_LOCK:
+                    tab = _SETTINGS_REGISTRY.get(tab_name)
+                    if tab is not None:
+                        tab.fields.extend(clean)
+                        logger.debug(
+                            "Applied %d deferred settings fields for plugin %s", len(clean), stem
+                        )
+        except Exception:
+            logger.exception("Error applying deferred settings fields for plugin: %s", stem)
+
+    if pending:
+        # Rebuild config cache so config.get() reflects the newly-added fields.
+        from shelfmark.core.config import config as _cfg2
+
+        try:
+            _cfg2.refresh(force=True)
+        except Exception:  # noqa: BLE001
+            logger.debug("config.refresh() after deferred field apply raised — cache may be stale")
+
+
+def _install_custom_source_requirements(custom_dir: object) -> None:
+    """Install packages from custom_sources/requirements.txt if it exists."""
+    import subprocess
+    import sys
+
+    req_file = custom_dir / "requirements.txt"  # type: ignore[operator]
+    if not req_file.is_file():
+        return
+
+    logger.info("Installing custom source dependencies from %s — this may take a moment…", req_file)
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-r",
+                str(req_file),
+                "--quiet",
+                "--disable-pip-version-check",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        if result.returncode == 0:
+            logger.info("Custom source dependencies installed successfully.")
+        else:
+            logger.warning(
+                "Custom source dependency install finished with errors:\n%s",
+                result.stderr.strip(),
+            )
+    except Exception:
+        logger.exception("Failed to install custom source dependencies from %s", req_file)
+
+
+def _load_custom_sources() -> None:
+    """Load user-defined source plugins from $CONFIG_DIR/custom_sources/*.py."""
+    import importlib.util
+    import re
+    import sys
+    from importlib.abc import Loader
+
+    from shelfmark.config.env import CONFIG_DIR
+
+    custom_dir = CONFIG_DIR / "custom_sources"
+    if not custom_dir.is_dir():
+        return
+
+    _install_custom_source_requirements(custom_dir)
+
+    loaded_count = 0
+    used_stems: set[str] = set()
+    for plugin_file in sorted(custom_dir.glob("*.py")):
+        if plugin_file.name.startswith("_"):
+            continue
+
+        # Sanitize the file stem so it's safe to embed in Python identifiers
+        # and config key names. A filename like "my-source.py" would otherwise
+        # produce an invalid module name and a broken config key.
+        safe_stem = re.sub(r"[^a-zA-Z0-9_]", "_", plugin_file.stem).strip("_")
+        if not safe_stem:
+            logger.warning(
+                "Plugin %s: filename produces an empty identifier after sanitization — skipping",
+                plugin_file.name,
+            )
+            continue
+        if safe_stem != plugin_file.stem:
+            logger.info(
+                "Plugin %s: stem sanitized from %r to %r for config keys",
+                plugin_file.name,
+                plugin_file.stem,
+                safe_stem,
+            )
+        if safe_stem in used_stems:
+            logger.warning(
+                "Plugin %s: sanitized stem %r collides with an already-loaded plugin — skipping",
+                plugin_file.name,
+                safe_stem,
+            )
+            continue
+        # NOTE: used_stems.add(safe_stem) is called only after a successful load
+        # so that a broken plugin (syntax error, import failure) does not block
+        # a valid sibling that maps to the same sanitized stem.
+
+        module_name = f"shelfmark_custom_{safe_stem}"
+
+        # Full registry snapshot before each plugin so we can detect overwrites
+        # (same source name = same key, so key-set diffs miss it) and do a clean
+        # rollback on any failure — including partial registrations mid-module.
+        sources_snapshot = dict(_SOURCES)
+        handlers_snapshot = dict(_HANDLERS)
+        enable_keys_snapshot = dict(_CUSTOM_SOURCE_ENABLE_KEYS)
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, plugin_file)
+            if spec is None or not isinstance(spec.loader, Loader):
+                logger.warning(
+                    "Could not create module spec for custom source: %s", plugin_file.name
+                )
+                continue
+            module = importlib.util.module_from_spec(spec)
+            # Register in sys.modules BEFORE exec so that @dataclass and other
+            # metaclass machinery can resolve cls.__module__ back to this module.
+            sys.modules[module_name] = module
+            try:
+                spec.loader.exec_module(module)
+            except Exception:
+                sys.modules.pop(module_name, None)
+                raise
+
+            new_sources = set(_SOURCES.keys()) - set(sources_snapshot.keys())
+
+            # Detect overwrites of ANY previously registered source or handler
+            # (built-in OR a plugin already loaded this session).
+            overwritten = {
+                n for n in sources_snapshot if _SOURCES.get(n) is not sources_snapshot[n]
+            } | {n for n in handlers_snapshot if _HANDLERS.get(n) is not handlers_snapshot[n]}
+            if overwritten:
+                logger.warning(
+                    "Plugin %s tried to overwrite already-registered name(s) %s — skipping plugin",
+                    plugin_file.name,
+                    overwritten,
+                )
+                _SOURCES.clear()
+                _SOURCES.update(sources_snapshot)
+                _HANDLERS.clear()
+                _HANDLERS.update(handlers_snapshot)
+                sys.modules.pop(module_name, None)
+                continue
+
+            _register_custom_source_settings(
+                safe_stem, module, new_sources, order=59 + loaded_count
+            )
+            loaded_count += 1
+            used_stems.add(safe_stem)
+            logger.info("Loaded custom source plugin: %s", plugin_file.name)
+        except Exception:
+            # Full rollback: restore all three registries to their pre-plugin state.
+            _SOURCES.clear()
+            _SOURCES.update(sources_snapshot)
+            _HANDLERS.clear()
+            _HANDLERS.update(handlers_snapshot)
+            _CUSTOM_SOURCE_ENABLE_KEYS.clear()
+            _CUSTOM_SOURCE_ENABLE_KEYS.update(enable_keys_snapshot)
+            logger.exception("Failed to load custom source plugin: %s", plugin_file.name)
 
 
 def _ensure_builtin_sources_registered() -> None:
     """Import built-in source modules once to populate source registries."""
     if _builtin_source_state["loaded"]:
         return
+    _builtin_source_state["loaded"] = True  # set early to prevent re-entrancy
 
     for module_name in _BUILTIN_SOURCE_MODULES:
-        import_module(module_name)
+        try:
+            import_module(module_name)
+        except Exception:
+            logger.exception("Failed to import builtin source module: %s", module_name)
 
-    _builtin_source_state["loaded"] = True
+    _load_custom_sources()
 
 
 def register_source(
@@ -451,15 +802,22 @@ def register_handler(
 def get_source(name: str) -> ReleaseSource:
     """Get a release source instance by name."""
     _ensure_builtin_sources_registered()
+    _apply_deferred_field_updates()
     if name not in _SOURCES:
         msg = f"Unknown release source: {name}"
         raise ValueError(msg)
+    if name in _CUSTOM_SOURCE_ENABLE_KEYS:
+        from shelfmark.core.config import config
+
+        if not config.get(_CUSTOM_SOURCE_ENABLE_KEYS[name], True):
+            raise SourceUnavailableError(f"Source '{name}' is disabled")
     return _SOURCES[name]()
 
 
 def get_handler(name: str) -> DownloadHandler:
     """Get a download handler instance by name."""
     _ensure_builtin_sources_registered()
+    _apply_deferred_field_updates()
     if name not in _HANDLERS:
         msg = f"Unknown download handler: {name}"
         raise ValueError(msg)
@@ -469,14 +827,38 @@ def get_handler(name: str) -> DownloadHandler:
 def list_available_sources() -> list[dict]:
     """List all registered sources with their availability status."""
     _ensure_builtin_sources_registered()
+    _apply_deferred_field_updates()
+    from shelfmark.core.config import config
+
     result = []
     for name, src_class in _SOURCES.items():
+        # Check Shelfmark's own enable toggle BEFORE instantiating the plugin.
+        # A disabled plugin may have a broken __init__ that raises, and we must
+        # not let that crash the whole source list.
+        if name in _CUSTOM_SOURCE_ENABLE_KEYS and not config.get(
+            _CUSTOM_SOURCE_ENABLE_KEYS[name], True
+        ):
+            result.append(
+                {
+                    "name": name,
+                    "display_name": src_class.display_name,
+                    "enabled": False,
+                    "supported_content_types": getattr(
+                        src_class, "supported_content_types", ["ebook", "audiobook"]
+                    ),
+                    "browse_results_are_releases": False,
+                    "can_be_default": getattr(src_class, "can_be_default", True),
+                }
+            )
+            continue
+
         instance = src_class()
+        enabled = instance.is_available()
         result.append(
             {
                 "name": name,
                 "display_name": instance.display_name,
-                "enabled": instance.is_available(),
+                "enabled": enabled,
                 "supported_content_types": getattr(
                     instance, "supported_content_types", ["ebook", "audiobook"]
                 ),
@@ -537,6 +919,3 @@ def source_results_are_releases(name: str) -> bool:
     if name not in _SOURCES:
         return False
     return _SOURCES[name]().search_results_are_releases()
-
-
-_ensure_builtin_sources_registered()

--- a/shelfmark/release_sources/audiobookbay/scraper.py
+++ b/shelfmark/release_sources/audiobookbay/scraper.py
@@ -417,6 +417,18 @@ def extract_magnet_link(details_url: str, hostname: str = "audiobookbay.lu") -> 
         # Clean up info hash (remove whitespace, ensure uppercase)
         info_hash = re.sub(r"\s+", "", info_hash).upper()
 
+        # Validate: SHA1 = 40 hex chars, SHA256 = 64 hex chars
+        if not re.match(r'^[0-9A-F]{40}$|^[0-9A-F]{64}$', info_hash):
+            logger.warning("Info Hash invalid (got %r), trying magnet fallback.", info_hash)
+            # Fallback: search entire page for a complete magnet link (e.g. posted in comments)
+            magnet_match = re.search(r'magnet:\?xt=urn:btih:([0-9a-fA-F]{40,64})', detail_html)
+            if magnet_match:
+                info_hash = magnet_match.group(1).upper()
+                logger.info("Found hash via magnet fallback: %s", info_hash)
+            else:
+                logger.warning("No valid magnet link found on page, giving up.")
+                return None
+
         # 2. Extract Trackers
         # Find all <td> containing udp:// or http://
         trackers = []

--- a/shelfmark/release_sources/audiobookbay/source.py
+++ b/shelfmark/release_sources/audiobookbay/source.py
@@ -238,8 +238,8 @@ class AudiobookBaySource(ReleaseSource):
                     exact_phrase=exact_phrase,
                 )
 
-                # For auto-generated queries, fallback to broad matching if exact phrase returns nothing.
-                if exact_phrase and not results and not plan.manual_query:
+                # Fallback to broad matching if exact phrase returns nothing (manual or auto query).
+                if exact_phrase and not results:
                     logger.info(
                         "No exact phrase results, retrying AudiobookBay search without quotes"
                     )
@@ -288,7 +288,7 @@ class AudiobookBaySource(ReleaseSource):
                     size_str = result.get("size")
                     size_bytes = parse_size(size_str) if size_str else None
                     language_raw = result.get("language")
-                    language_code = _map_language(language_raw) if language_raw else None
+                    language_code = _map_language(language_raw) if language_raw else "en"
                     bitrate = result.get("bitrate")
                     bitrate_kbps = _parse_bitrate_to_kbps(bitrate)
 

--- a/src/frontend/src/components/settings/fields/HeadingField.tsx
+++ b/src/frontend/src/components/settings/fields/HeadingField.tsx
@@ -8,7 +8,7 @@ export const HeadingField = ({ field }: HeadingFieldProps) => (
   <div className="pb-1 not-first:mt-1 not-first:border-t not-first:border-(--border-muted) not-first:pt-5">
     <h3 className="mb-1 text-base font-semibold">{field.title}</h3>
     {field.description && (
-      <p className="text-sm opacity-70">
+      <p className="whitespace-pre-line text-sm opacity-70">
         {field.description}
         {field.linkUrl && (
           <>

--- a/tests/release_sources/__init__.py
+++ b/tests/release_sources/__init__.py
@@ -1,0 +1,31 @@
+"""
+Stub out flask_socketio only when it is not actually installed, so the IRC
+source can be imported in lightweight test environments without the real
+dependency. In full dev environments the real package is used as-is.
+"""
+
+import sys
+import types
+
+
+def _stub_module_if_missing(name: str, attrs: dict) -> None:
+    if name in sys.modules:
+        return
+    try:
+        __import__(name)
+    except ImportError:
+        stub = types.ModuleType(name)
+        for attr, value in attrs.items():
+            setattr(stub, attr, value)
+        sys.modules[name] = stub
+
+
+_stub_module_if_missing(
+    "flask_socketio",
+    {
+        "SocketIO": object,
+        "emit": lambda *a, **kw: None,
+        "join_room": lambda *a, **kw: None,
+        "leave_room": lambda *a, **kw: None,
+    },
+)

--- a/tests/release_sources/test_custom_sources.py
+++ b/tests/release_sources/test_custom_sources.py
@@ -1,0 +1,739 @@
+"""Tests for the custom source plugin loading mechanism."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+from threading import Event
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+import shelfmark.release_sources as rs
+from shelfmark.release_sources import (
+    Release,
+    ReleaseSource,
+    _load_custom_sources,
+    list_available_sources,
+    register_source,
+)
+
+if TYPE_CHECKING:
+    from shelfmark.core.search_plan import ReleaseSearchPlan
+    from shelfmark.metadata_providers import BookMetadata
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Snapshot the registry + loaded flag before each test and restore after."""
+    from shelfmark.core.settings_registry import _SETTINGS_REGISTRY
+
+    saved_sources = dict(rs._SOURCES)
+    saved_handlers = dict(rs._HANDLERS)
+    saved_enable_keys = dict(rs._CUSTOM_SOURCE_ENABLE_KEYS)
+    saved_state = dict(rs._builtin_source_state)
+    saved_settings = dict(_SETTINGS_REGISTRY)
+    saved_deferred = dict(rs._deferred_field_updates)
+
+    rs._builtin_source_state["loaded"] = True
+
+    yield
+
+    rs._SOURCES.clear()
+    rs._SOURCES.update(saved_sources)
+    rs._HANDLERS.clear()
+    rs._HANDLERS.update(saved_handlers)
+    rs._CUSTOM_SOURCE_ENABLE_KEYS.clear()
+    rs._CUSTOM_SOURCE_ENABLE_KEYS.update(saved_enable_keys)
+    rs._builtin_source_state.clear()
+    rs._builtin_source_state.update(saved_state)
+    _SETTINGS_REGISTRY.clear()
+    _SETTINGS_REGISTRY.update(saved_settings)
+    rs._deferred_field_updates.clear()
+    rs._deferred_field_updates.update(saved_deferred)
+
+
+@pytest.fixture()
+def custom_sources_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a temp CONFIG_DIR/custom_sources/ and point the module at it."""
+    custom_dir = tmp_path / "config" / "custom_sources"
+    custom_dir.mkdir(parents=True)
+
+    import shelfmark.config.env as env_module
+
+    monkeypatch.setattr(env_module, "CONFIG_DIR", tmp_path / "config")
+    return custom_dir
+
+
+# ---------------------------------------------------------------------------
+# Minimal plugin template written into temp files
+# ---------------------------------------------------------------------------
+
+_MINIMAL_PLUGIN = dedent(
+    """
+    from threading import Event
+    from shelfmark.release_sources import (
+        DownloadHandler, Release, ReleaseSource,
+        register_handler, register_source,
+    )
+
+    SOURCE_NAME = "{name}"
+
+    @register_source(SOURCE_NAME)
+    class _Source(ReleaseSource):
+        name = SOURCE_NAME
+        display_name = "{display}"
+
+        def is_available(self):
+            return True
+
+        def search(self, book, plan, *, expand_search=False, content_type="ebook"):
+            return [
+                Release(
+                    source=SOURCE_NAME,
+                    source_id="1",
+                    title="Test Book",
+                )
+            ]
+
+    @register_handler(SOURCE_NAME)
+    class _Handler(DownloadHandler):
+        def download(self, task, cancel_flag, progress_callback, status_callback):
+            return "/tmp/fake.epub"
+
+        def cancel(self, task_id):
+            return True
+    """
+)
+
+
+def _write_plugin(directory: Path, filename: str, name: str, display: str = "Test Source") -> Path:
+    path = directory / filename
+    path.write_text(_MINIMAL_PLUGIN.format(name=name, display=display))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests: directory / file discovery
+# ---------------------------------------------------------------------------
+
+
+def test_no_custom_sources_dir_is_silent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_load_custom_sources silently returns when the directory doesn't exist."""
+    import shelfmark.config.env as env_module
+
+    monkeypatch.setattr(env_module, "CONFIG_DIR", tmp_path / "does_not_exist")
+
+    before = dict(rs._SOURCES)
+    _load_custom_sources()
+    assert rs._SOURCES == before
+
+
+def test_empty_custom_sources_dir_is_silent(custom_sources_dir: Path) -> None:
+    """An empty custom_sources/ directory leaves the registry unchanged."""
+    before = dict(rs._SOURCES)
+    _load_custom_sources()
+    assert rs._SOURCES == before
+
+
+def test_underscore_files_are_skipped(custom_sources_dir: Path) -> None:
+    """Files whose names start with _ are not loaded."""
+    _write_plugin(custom_sources_dir, "_private.py", "private_source")
+    _load_custom_sources()
+    assert "private_source" not in rs._SOURCES
+
+
+def test_non_python_files_are_skipped(custom_sources_dir: Path) -> None:
+    """Non-.py files in custom_sources/ are ignored."""
+    (custom_sources_dir / "readme.txt").write_text("just a note")
+    (custom_sources_dir / "config.json").write_text("{}")
+    before = dict(rs._SOURCES)
+    _load_custom_sources()
+    assert rs._SOURCES == before
+
+
+# ---------------------------------------------------------------------------
+# Tests: successful loading
+# ---------------------------------------------------------------------------
+
+
+def test_valid_plugin_registers_source_and_handler(custom_sources_dir: Path) -> None:
+    """A well-formed plugin file registers both its source and handler."""
+    _write_plugin(custom_sources_dir, "my_tracker.py", "my_tracker")
+
+    _load_custom_sources()
+
+    assert "my_tracker" in rs._SOURCES
+    assert "my_tracker" in rs._HANDLERS
+
+
+def test_loaded_source_is_callable(custom_sources_dir: Path) -> None:
+    """The registered source can be instantiated and its methods work."""
+    _write_plugin(custom_sources_dir, "callable_source.py", "callable_source", "Callable Source")
+
+    _load_custom_sources()
+
+    source = rs._SOURCES["callable_source"]()
+    assert source.display_name == "Callable Source"
+    assert source.is_available() is True
+
+
+def test_loaded_source_search_returns_releases(custom_sources_dir: Path) -> None:
+    """search() on the loaded source returns a list of Release objects."""
+    from unittest.mock import MagicMock
+
+    _write_plugin(custom_sources_dir, "search_source.py", "search_source")
+    _load_custom_sources()
+
+    source = rs._SOURCES["search_source"]()
+    book = MagicMock()
+    plan = MagicMock()
+    results = source.search(book, plan)
+
+    assert len(results) == 1
+    assert isinstance(results[0], Release)
+    assert results[0].source == "search_source"
+
+
+def test_loaded_handler_download_returns_path(custom_sources_dir: Path) -> None:
+    """download() on the loaded handler returns a path string."""
+    from unittest.mock import MagicMock
+
+    _write_plugin(custom_sources_dir, "download_handler.py", "download_handler")
+    _load_custom_sources()
+
+    handler = rs._HANDLERS["download_handler"]()
+    result = handler.download(
+        task=MagicMock(),
+        cancel_flag=Event(),
+        progress_callback=lambda _: None,
+        status_callback=lambda *_: None,
+    )
+    assert result == "/tmp/fake.epub"
+
+
+def test_multiple_plugins_all_loaded(custom_sources_dir: Path) -> None:
+    """All .py files in custom_sources/ are loaded, not just the first."""
+    _write_plugin(custom_sources_dir, "alpha.py", "alpha_source")
+    _write_plugin(custom_sources_dir, "beta.py", "beta_source")
+    _write_plugin(custom_sources_dir, "gamma.py", "gamma_source")
+
+    _load_custom_sources()
+
+    assert "alpha_source" in rs._SOURCES
+    assert "beta_source" in rs._SOURCES
+    assert "gamma_source" in rs._SOURCES
+
+
+def test_plugins_loaded_in_sorted_order(custom_sources_dir: Path) -> None:
+    """Plugins are processed in sorted (deterministic) filename order."""
+    _write_plugin(custom_sources_dir, "zzz_last.py", "zzz_last_source")
+    _write_plugin(custom_sources_dir, "aaa_first.py", "aaa_first_source")
+
+    _load_custom_sources()
+
+    # Python dicts preserve insertion order; sorted load means aaa comes first.
+    keys = list(rs._SOURCES.keys())
+    assert keys.index("aaa_first_source") < keys.index("zzz_last_source")
+
+
+# ---------------------------------------------------------------------------
+# Tests: error handling / isolation
+# ---------------------------------------------------------------------------
+
+
+def test_broken_plugin_does_not_prevent_others_loading(custom_sources_dir: Path) -> None:
+    """A plugin with a syntax error is skipped; subsequent plugins still load."""
+    (custom_sources_dir / "broken.py").write_text("this is not valid python !!!")
+    _write_plugin(custom_sources_dir, "good.py", "good_source")
+
+    _load_custom_sources()
+
+    assert "good_source" in rs._SOURCES
+
+
+def test_broken_plugin_logs_exception(custom_sources_dir: Path) -> None:
+    """A broken plugin emits an exception-level log with the filename."""
+    (custom_sources_dir / "bad_import.py").write_text("import no_such_module_xyz")
+
+    with patch.object(rs.logger, "exception") as mock_exc:
+        _load_custom_sources()
+
+    assert mock_exc.called
+    # Second positional arg to logger.exception(..., plugin_file.name) is the filename
+    assert any("bad_import.py" in str(call) for call in mock_exc.call_args_list)
+
+
+def test_runtime_error_in_plugin_is_isolated(custom_sources_dir: Path) -> None:
+    """A plugin that raises at module level is caught without propagating."""
+    (custom_sources_dir / "runtime_error.py").write_text(
+        "raise RuntimeError('intentional test error')"
+    )
+
+    # Must not raise
+    _load_custom_sources()
+
+
+def test_spec_none_plugin_logs_warning(custom_sources_dir: Path) -> None:
+    """If spec_from_file_location returns None, a warning is logged and source is skipped."""
+    _write_plugin(custom_sources_dir, "unloadable.py", "unloadable_source")
+
+    with patch.object(rs.logger, "warning") as mock_warn:
+        with patch("importlib.util.spec_from_file_location", return_value=None):
+            _load_custom_sources()
+
+    assert mock_warn.called
+    assert any("unloadable.py" in str(call) for call in mock_warn.call_args_list)
+    assert "unloadable_source" not in rs._SOURCES
+
+
+# ---------------------------------------------------------------------------
+# Tests: integration with public API
+# ---------------------------------------------------------------------------
+
+
+def test_custom_source_appears_in_list_available_sources(custom_sources_dir: Path) -> None:
+    """A loaded plugin is visible in list_available_sources()."""
+    _write_plugin(custom_sources_dir, "listed.py", "listed_source", "Listed Source")
+    _load_custom_sources()
+
+    names = [s["name"] for s in list_available_sources()]
+    assert "listed_source" in names
+
+
+def test_custom_source_listed_as_enabled(custom_sources_dir: Path) -> None:
+    """is_available()=True causes the source to be listed as enabled."""
+    _write_plugin(custom_sources_dir, "enabled.py", "enabled_source")
+    _load_custom_sources()
+
+    info = next(s for s in list_available_sources() if s["name"] == "enabled_source")
+    assert info["enabled"] is True
+
+
+def test_custom_source_unavailable_plugin() -> None:
+    """A source whose is_available() returns False is listed as disabled."""
+
+    @register_source("unavailable_test_source")
+    class _UnavailableSource(ReleaseSource):
+        name = "unavailable_test_source"
+        display_name = "Unavailable Test"
+
+        def is_available(self) -> bool:
+            return False
+
+        def search(self, book: BookMetadata, plan: ReleaseSearchPlan, **_: object) -> list[Release]:
+            return []
+
+    info = next(s for s in list_available_sources() if s["name"] == "unavailable_test_source")
+    assert info["enabled"] is False
+
+
+def test_custom_source_can_be_retrieved_by_name(custom_sources_dir: Path) -> None:
+    """get_source() returns an instance of the loaded plugin class."""
+    from shelfmark.release_sources import get_source
+
+    _write_plugin(custom_sources_dir, "named.py", "named_source", "Named Source")
+    _load_custom_sources()
+
+    source = get_source("named_source")
+    assert source.display_name == "Named Source"
+
+
+def test_custom_handler_can_be_retrieved_by_name(custom_sources_dir: Path) -> None:
+    """get_handler() returns an instance of the loaded plugin handler."""
+    from shelfmark.release_sources import get_handler
+
+    _write_plugin(custom_sources_dir, "handled.py", "handled_source")
+    _load_custom_sources()
+
+    handler = get_handler("handled_source")
+    assert handler.cancel("any_id") is True
+
+
+def test_plugin_does_not_overwrite_builtin(custom_sources_dir: Path) -> None:
+    """A plugin that tries to overwrite a built-in source is rejected and the built-in survives."""
+    rs._builtin_source_state["loaded"] = False
+    rs._ensure_builtin_sources_registered()
+
+    original_direct = rs._SOURCES.get("direct_download")
+    assert original_direct is not None, "direct_download must be a loaded built-in for this test"
+
+    # Write a plugin that deliberately re-registers the built-in name.
+    (custom_sources_dir / "hijack.py").write_text(
+        """
+from shelfmark.release_sources import ReleaseSource, DownloadHandler, Release, register_source, register_handler
+
+@register_source("direct_download")
+class _S(ReleaseSource):
+    name = "direct_download"
+    display_name = "Hijacked"
+    def is_available(self): return True
+    def search(self, *a, **kw): return []
+
+@register_handler("direct_download")
+class _H(DownloadHandler):
+    def download(self, *a, **kw): return None
+    def cancel(self, task_id): return True
+"""
+    )
+    _load_custom_sources()
+
+    # Built-in must be intact — the plugin should have been rejected.
+    assert rs._SOURCES.get("direct_download") is original_direct
+
+
+def test_two_custom_plugins_same_name_second_rejected(custom_sources_dir: Path) -> None:
+    """When two custom plugins register the same source name, the second is rejected."""
+    _write_plugin(custom_sources_dir, "alpha.py", "shared_name", "Alpha")
+    _write_plugin(custom_sources_dir, "beta.py", "shared_name", "Beta")
+
+    _load_custom_sources()
+
+    # Exactly one should win — the first (alpha, sorted first).
+    assert "shared_name" in rs._SOURCES
+    assert rs._SOURCES["shared_name"].display_name == "Alpha"
+
+
+def test_disabled_plugin_with_throwing_init_does_not_crash_list(custom_sources_dir: Path) -> None:
+    """list_available_sources() must not crash when a disabled plugin's __init__ raises."""
+    plugin_code = """
+from shelfmark.release_sources import ReleaseSource, DownloadHandler, Release, register_source, register_handler
+
+@register_source("crashing_source")
+class _S(ReleaseSource):
+    name = "crashing_source"
+    display_name = "Crasher"
+
+    def __init__(self):
+        raise RuntimeError("intentional crash in __init__")
+
+    def is_available(self): return True
+    def search(self, *a, **kw): return []
+
+@register_handler("crashing_source")
+class _H(DownloadHandler):
+    def download(self, *a, **kw): return None
+    def cancel(self, task_id): return True
+"""
+    (custom_sources_dir / "crasher.py").write_text(plugin_code)
+    _load_custom_sources()
+
+    enable_key = rs._CUSTOM_SOURCE_ENABLE_KEYS.get("crashing_source")
+    assert enable_key is not None
+
+    with patch.object(
+        __import__("shelfmark.core.config", fromlist=["config"]).config,
+        "get",
+        side_effect=lambda k, d=None, **kw: False if k == enable_key else d,
+    ):
+        # Must not raise — disabled plugin's __init__ is never called.
+        sources = list_available_sources()
+
+    names = [s["name"] for s in sources]
+    assert "crashing_source" in names
+    crashed_entry = next(s for s in sources if s["name"] == "crashing_source")
+    assert crashed_entry["enabled"] is False
+
+
+def test_plugin_with_hyphenated_filename_loads(custom_sources_dir: Path) -> None:
+    """A plugin file with hyphens in the name is sanitized and loaded correctly."""
+    _write_plugin(custom_sources_dir, "my-source.py", "my_hyphen_source", "Hyphen Source")
+
+    _load_custom_sources()
+
+    assert "my_hyphen_source" in rs._SOURCES
+
+
+def test_plugin_inserted_into_sys_modules_before_exec(custom_sources_dir: Path) -> None:
+    """Plugin module is in sys.modules during execution so @dataclass helpers resolve."""
+    import sys
+
+    plugin_code = """
+from dataclasses import dataclass
+from shelfmark.release_sources import ReleaseSource, DownloadHandler, Release, register_source, register_handler
+
+@dataclass
+class _Config:
+    max_results: int = 10
+
+@register_source("dataclass_source")
+class _S(ReleaseSource):
+    name = "dataclass_source"
+    display_name = "Dataclass Source"
+    def is_available(self): return True
+    def search(self, *a, **kw): return []
+
+@register_handler("dataclass_source")
+class _H(DownloadHandler):
+    def download(self, *a, **kw): return None
+    def cancel(self, task_id): return True
+"""
+    (custom_sources_dir / "dataclass_plugin.py").write_text(plugin_code)
+
+    _load_custom_sources()
+
+    assert "dataclass_source" in rs._SOURCES
+    assert "shelfmark_custom_dataclass_plugin" in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# Tests: re-entrancy guard
+# ---------------------------------------------------------------------------
+
+
+def test_reentrancy_guard_prevents_double_load(custom_sources_dir: Path) -> None:
+    """Calling _ensure_builtin_sources_registered twice only loads custom sources once."""
+    _write_plugin(custom_sources_dir, "once.py", "once_source")
+
+    rs._builtin_source_state["loaded"] = False
+    rs._ensure_builtin_sources_registered()
+    count_after_first = sum(1 for n in rs._SOURCES if n == "once_source")
+
+    # Second call must be a no-op
+    rs._ensure_builtin_sources_registered()
+    count_after_second = sum(1 for n in rs._SOURCES if n == "once_source")
+
+    assert count_after_first == count_after_second == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: Shelfmark-controlled enable/disable toggle
+# ---------------------------------------------------------------------------
+
+
+def test_enable_key_registered_for_custom_source(custom_sources_dir: Path) -> None:
+    """Loading a plugin registers its enable key in _CUSTOM_SOURCE_ENABLE_KEYS."""
+    _write_plugin(custom_sources_dir, "toggle_source.py", "toggle_source")
+    _load_custom_sources()
+
+    assert "toggle_source" in rs._CUSTOM_SOURCE_ENABLE_KEYS
+    assert rs._CUSTOM_SOURCE_ENABLE_KEYS["toggle_source"] == "CUSTOM_TOGGLE_SOURCE_ENABLED"
+
+
+def _mock_config(enabled_key: str, *, enabled: bool):
+    """Patch config.get on the real singleton to control a single enable key."""
+    from shelfmark.core.config import config as real_config
+
+    original_get = real_config.get
+
+    def _patched_get(key: str, default: object = None, **kwargs: object) -> object:
+        if key == enabled_key:
+            return enabled
+        return original_get(key, default, **kwargs)
+
+    return patch.object(real_config, "get", side_effect=_patched_get)
+
+
+def test_disabled_via_shelfmark_config_overrides_plugin(custom_sources_dir: Path) -> None:
+    """When the Shelfmark toggle is off, the source shows as disabled regardless of is_available()."""
+    _write_plugin(custom_sources_dir, "always_up.py", "always_up_source")
+    _load_custom_sources()
+
+    # Confirm the plugin's own is_available() returns True without any patching
+    assert rs._SOURCES["always_up_source"]().is_available() is True
+
+    # Look up the actual enable key Shelfmark assigned (based on filename stem, not source name)
+    enable_key = rs._CUSTOM_SOURCE_ENABLE_KEYS["always_up_source"]
+
+    with _mock_config(enable_key, enabled=False):
+        info = next(s for s in list_available_sources() if s["name"] == "always_up_source")
+
+    assert info["enabled"] is False
+
+
+def test_plugin_cannot_circumvent_shelfmark_disable(custom_sources_dir: Path) -> None:
+    """Even a plugin with hardcoded is_available()=True is disabled by Shelfmark's toggle."""
+    plugin_code = dedent("""
+        from shelfmark.release_sources import ReleaseSource, DownloadHandler, Release, register_source, register_handler
+
+        @register_source("stubborn_source")
+        class _S(ReleaseSource):
+            name = "stubborn_source"
+            display_name = "Stubborn"
+            def is_available(self): return True  # hardcoded — plugin can't override the toggle
+            def search(self, *a, **kw): return []
+
+        @register_handler("stubborn_source")
+        class _H(DownloadHandler):
+            def download(self, *a, **kw): return None
+            def cancel(self, task_id): return True
+    """)
+    (custom_sources_dir / "stubborn.py").write_text(plugin_code)
+    _load_custom_sources()
+
+    enable_key = rs._CUSTOM_SOURCE_ENABLE_KEYS["stubborn_source"]
+    with _mock_config(enable_key, enabled=False):
+        info = next(s for s in list_available_sources() if s["name"] == "stubborn_source")
+
+    assert info["enabled"] is False
+
+
+def test_enabled_toggle_still_consults_plugin_is_available(custom_sources_dir: Path) -> None:
+    """When Shelfmark toggle is on, the plugin's own is_available() is still consulted."""
+    _write_plugin(custom_sources_dir, "checked.py", "checked_source")
+    _load_custom_sources()
+
+    enable_key = rs._CUSTOM_SOURCE_ENABLE_KEYS["checked_source"]
+    with _mock_config(enable_key, enabled=True):
+        info = next(s for s in list_available_sources() if s["name"] == "checked_source")
+
+    assert info["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: deferred field updates
+# ---------------------------------------------------------------------------
+
+
+def test_deferred_fields_applied_on_list_available_sources(custom_sources_dir: Path) -> None:
+    """Fields stored in _deferred_field_updates are appended to the tab on the first source API call."""
+    from shelfmark.core.settings_registry import _SETTINGS_REGISTRY, TextField
+
+    _write_plugin(custom_sources_dir, "deferred.py", "deferred_source")
+    _load_custom_sources()
+
+    tab_name = "custom_deferred"
+
+    # Manually inject a deferred entry (simulates the lock-held startup path).
+    rs._deferred_field_updates[tab_name] = (
+        "deferred",
+        lambda: [TextField(key="DEFERRED_URL", label="URL", default="")],
+    )
+
+    # Verify the field is absent before the call.
+    assert tab_name in _SETTINGS_REGISTRY
+    keys_before = {f.key for f in _SETTINGS_REGISTRY[tab_name].fields}
+    assert "DEFERRED_URL" not in keys_before
+
+    # Trigger deferred application.
+    list_available_sources()
+
+    keys_after = {f.key for f in _SETTINGS_REGISTRY[tab_name].fields}
+    assert "DEFERRED_URL" in keys_after
+    assert not rs._deferred_field_updates  # queue cleared
+
+
+def test_deferred_fields_refresh_config_cache(custom_sources_dir: Path) -> None:
+    """Applying deferred fields refreshes config so config.get() can see those keys."""
+    from shelfmark.core.config import config
+    from shelfmark.core.settings_registry import TextField
+
+    _write_plugin(custom_sources_dir, "deferred_config.py", "deferred_config_source")
+    _load_custom_sources()
+
+    rs._deferred_field_updates["custom_deferred_config"] = (
+        "deferred_config",
+        lambda: [TextField(key="DEFERRED_CONFIG_URL", label="URL", default="")],
+    )
+
+    with patch.object(config, "refresh") as mock_refresh:
+        list_available_sources()
+
+    mock_refresh.assert_called_once_with(force=True)
+
+
+def test_deferred_fields_blocked_for_shelfmark_owned_key(custom_sources_dir: Path) -> None:
+    """A deferred field with the same key as the Shelfmark enable toggle is rejected."""
+    from shelfmark.core.settings_registry import _SETTINGS_REGISTRY, CheckboxField
+
+    _write_plugin(custom_sources_dir, "owned_key.py", "owned_key_source")
+    _load_custom_sources()
+
+    enable_key = rs._CUSTOM_SOURCE_ENABLE_KEYS["owned_key_source"]
+    tab_name = "custom_owned_key"
+
+    # Inject a deferred field that conflicts with the enable toggle key.
+    from shelfmark.core.settings_registry import TextField
+
+    rs._deferred_field_updates[tab_name] = (
+        "owned_key",
+        lambda: [TextField(key=enable_key, label="Evil", default="")],
+    )
+
+    list_available_sources()
+
+    # The conflicting field must have been dropped; the tab still has the original checkbox.
+    enable_fields = [
+        f for f in _SETTINGS_REGISTRY[tab_name].fields if getattr(f, "key", None) == enable_key
+    ]
+    assert len(enable_fields) == 1
+    assert isinstance(enable_fields[0], CheckboxField)
+
+
+def test_same_plugin_duplicate_keys_deduplicated(custom_sources_dir: Path) -> None:
+    """get_settings_fields() returning two fields with the same key: second is dropped."""
+    from shelfmark.core.settings_registry import _SETTINGS_REGISTRY
+
+    plugin_code = dedent("""
+        from shelfmark.release_sources import ReleaseSource, DownloadHandler, Release, register_source, register_handler
+        from shelfmark.core.settings_registry import TextField
+
+        @register_source("dup_key_source")
+        class _S(ReleaseSource):
+            name = "dup_key_source"
+            display_name = "Dup Key"
+            def is_available(self): return True
+            def search(self, *a, **kw): return []
+
+        @register_handler("dup_key_source")
+        class _H(DownloadHandler):
+            def download(self, *a, **kw): return None
+            def cancel(self, task_id): return True
+
+        def get_settings_fields():
+            return [
+                TextField(key="DUP_KEY_SOURCE_URL", label="First", default=""),
+                TextField(key="DUP_KEY_SOURCE_URL", label="Duplicate", default=""),
+            ]
+    """)
+    (custom_sources_dir / "dup_key.py").write_text(plugin_code)
+    _load_custom_sources()
+
+    tab = _SETTINGS_REGISTRY.get("custom_dup_key")
+    assert tab is not None
+    dup_fields = [f for f in tab.fields if getattr(f, "key", None) == "DUP_KEY_SOURCE_URL"]
+    assert len(dup_fields) == 1, "duplicate key should have been filtered to a single field"
+
+
+def test_shelfmark_owned_key_blocked_in_get_settings_fields(custom_sources_dir: Path) -> None:
+    """A plugin whose get_settings_fields() returns the Shelfmark enable key is silently dropped."""
+    from shelfmark.core.settings_registry import _SETTINGS_REGISTRY
+
+    plugin_code = dedent("""
+        from shelfmark.release_sources import ReleaseSource, DownloadHandler, Release, register_source, register_handler
+        from shelfmark.core.settings_registry import TextField
+
+        @register_source("owned_hijack")
+        class _S(ReleaseSource):
+            name = "owned_hijack"
+            display_name = "Hijack Owned"
+            def is_available(self): return True
+            def search(self, *a, **kw): return []
+
+        @register_handler("owned_hijack")
+        class _H(DownloadHandler):
+            def download(self, *a, **kw): return None
+            def cancel(self, task_id): return True
+
+        def get_settings_fields():
+            return [TextField(key="CUSTOM_OWNED_HIJACK_ENABLED", label="Evil", default="")]
+    """)
+    (custom_sources_dir / "owned_hijack.py").write_text(plugin_code)
+    _load_custom_sources()
+
+    tab = _SETTINGS_REGISTRY.get("custom_owned_hijack")
+    assert tab is not None
+    from shelfmark.core.settings_registry import CheckboxField
+
+    # The enable key must still be a CheckboxField, not a TextField.
+    enable_fields = [
+        f for f in tab.fields if getattr(f, "key", None) == "CUSTOM_OWNED_HIJACK_ENABLED"
+    ]
+    assert len(enable_fields) == 1
+    assert isinstance(enable_fields[0], CheckboxField)


### PR DESCRIPTION
Lets users add their own book search/download sources to Shelfmark by dropping a single Python file into `$CONFIG_DIR/custom_sources/` no changes to Shelfmark's own code required.

Plugins are discovered and loaded automatically at startup. 

Closes #1035 