### PR TITLE
Make SABnzbd API key optional

### DIFF
--- a/shelfmark/download/clients/sabnzbd.py
+++ b/shelfmark/download/clients/sabnzbd.py
@@ -135,16 +135,11 @@ class SABnzbdClient(DownloadClient):
             msg = "SABNZBD_URL is required"
             raise ValueError(msg)
 
-        api_key = config_text(config.get("SABNZBD_API_KEY", ""))
-        if not api_key:
-            msg = "SABNZBD_API_KEY is required"
-            raise ValueError(msg)
-
         self.url = normalize_http_config_url(raw_url)
         if not self.url:
             msg = "SABNZBD_URL is invalid"
             raise ValueError(msg)
-        self.api_key = api_key
+        self.api_key = config_text(config.get("SABNZBD_API_KEY", ""))
         self._category = config_text(config.get("SABNZBD_CATEGORY", "books"))
 
     @staticmethod
@@ -152,8 +147,7 @@ class SABnzbdClient(DownloadClient):
         """Check if SABnzbd is configured and selected as the usenet client."""
         client = config_text(config.get("PROWLARR_USENET_CLIENT", ""))
         url = normalize_http_config_url(config.get("SABNZBD_URL", ""))
-        api_key = config_text(config.get("SABNZBD_API_KEY", ""))
-        return client == "sabnzbd" and bool(url) and bool(api_key)
+        return client == "sabnzbd" and bool(url)
 
     @with_retry()
     def _api_call(self, mode: str, params: dict[str, _SabnzbdRequestParam] | None = None) -> Any:

--- a/shelfmark/download/clients/settings.py
+++ b/shelfmark/download/clients/settings.py
@@ -494,8 +494,6 @@ def _test_sabnzbd_connection(current_values: dict[str, Any] | None = None) -> di
     url = normalize_http_url(raw_url)
     if not url:
         return {"success": False, "message": "SABnzbd URL is invalid"}
-    if not api_key:
-        return {"success": False, "message": "API key is required"}
 
     try:
         api_url = f"{url.rstrip('/')}/api"
@@ -846,7 +844,7 @@ def prowlarr_clients_settings() -> list[SettingsField]:
         PasswordField(
             key="SABNZBD_API_KEY",
             label="API Key",
-            description="Found in SABnzbd: Config > General > API Key",
+            description="Found in SABnzbd: Config > General > API Key. Leave blank if SABnzbd has no API key set.",
             show_when={"field": "PROWLARR_USENET_CLIENT", "value": "sabnzbd"},
         ),
         ActionButton(

--- a/tests/prowlarr/test_sabnzbd_client.py
+++ b/tests/prowlarr/test_sabnzbd_client.py
@@ -68,7 +68,7 @@ class TestSABnzbdClientIsConfigured:
         assert SABnzbdClient.is_configured() is False
 
     def test_is_configured_no_api_key(self, monkeypatch):
-        """Test is_configured returns False when API key not set."""
+        """Test is_configured returns True when API key is not set (API key is optional)."""
         config_values = {
             "PROWLARR_USENET_CLIENT": "sabnzbd",
             "SABNZBD_URL": "http://localhost:8080",
@@ -83,7 +83,45 @@ class TestSABnzbdClientIsConfigured:
             SABnzbdClient,
         )
 
-        assert SABnzbdClient.is_configured() is False
+        assert SABnzbdClient.is_configured() is True
+
+
+class TestSABnzbdClientInit:
+    """Tests for SABnzbdClient.__init__()."""
+
+    def test_init_succeeds_without_api_key(self, monkeypatch):
+        """Test that SABnzbdClient can be initialised with an empty API key."""
+        config_values = {
+            "SABNZBD_URL": "http://localhost:8080",
+            "SABNZBD_API_KEY": "",
+            "SABNZBD_CATEGORY": "books",
+        }
+        monkeypatch.setattr(
+            "shelfmark.download.clients.sabnzbd.config.get",
+            lambda key, default="": config_values.get(key, default),
+        )
+
+        from shelfmark.download.clients.sabnzbd import SABnzbdClient
+
+        client = SABnzbdClient()
+        assert client.api_key == ""
+
+    def test_init_stores_api_key_when_provided(self, monkeypatch):
+        """Test that a provided API key is stored correctly."""
+        config_values = {
+            "SABNZBD_URL": "http://localhost:8080",
+            "SABNZBD_API_KEY": "abc123",
+            "SABNZBD_CATEGORY": "books",
+        }
+        monkeypatch.setattr(
+            "shelfmark.download.clients.sabnzbd.config.get",
+            lambda key, default="": config_values.get(key, default),
+        )
+
+        from shelfmark.download.clients.sabnzbd import SABnzbdClient
+
+        client = SABnzbdClient()
+        assert client.api_key == "abc123"
 
 
 class TestSABnzbdClientTestConnection:


### PR DESCRIPTION
Make SABnzbd API key optional for Real-Debrid Client when authentication is enabled.