### PR TITLE
use a stable hash for the Booklore options cache key

### DIFF
--- a/shelfmark/config/booklore_settings.py
+++ b/shelfmark/config/booklore_settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+import hashlib
 
 from shelfmark.core.config import config
 from shelfmark.core.logger import setup_logger
@@ -23,7 +24,7 @@ _BOOKLORE_OPTIONS_CACHE: dict[str, Any] = {
 
 
 def _get_booklore_cache_key(base_url: str, username: str, password: str) -> str:
-    return f"{base_url}|{username}|{hash(password)}"
+    return f"{base_url}|{username}|{hashlib.sha256(password.encode()).hexdigest()}"
 
 
 def _get_booklore_select_options(


### PR DESCRIPTION
`_get_booklore_cache_key` returned `f"{base_url}|{username}|{hash(password)}"`. Python's built-in `hash()` is randomized per process (`PYTHONHASHSEED`), so the cache key for the same Booklore credentials changed between every worker process and every restart. If the dashboard was opened by a worker that landed on a different seed than the worker that warmed the cache, the `_BOOKLORE_OPTIONS_CACHE.get("key") == cache_key` check would miss on every lookup, forcing a fresh `booklore_login` API call each time.

Switch to `hashlib.sha256(password.encode()).hexdigest()` — deterministic across processes and restarts. SHA-256 is overkill for a cache key, but matching the existing convention (`hashlib.sha1` is used elsewhere in the codebase) is what we want here.

The password is already in memory (it comes from the request body / `config.get`), so this doesn't introduce a new secret-handling concern.