### PR TITLE
Feat: Add torbox download client

### DIFF
--- a/shelfmark/config/settings.py
+++ b/shelfmark/config/settings.py
@@ -1498,6 +1498,15 @@ def download_source_settings() -> list[SettingsField]:
             label="Account Donator Key",
             description="Enables fast download access on AA. Get this from your donator account page.",
         ),
+        CheckboxField(
+            key="TORBOX_DIRECT_DOWNLOAD_ENABLED",
+            label="Use Torbox for Direct Downloads",
+            description=(
+                "Send Anna's Archive book pages to Torbox first, then download from its CDN. "
+                "Requires a Torbox API key configured in Download Clients."
+            ),
+            default=False,
+        ),
         HeadingField(
             key="source_priority_heading",
             title="Source Priority",

--- a/shelfmark/download/clients/__init__.py
+++ b/shelfmark/download/clients/__init__.py
@@ -381,6 +381,7 @@ _BUILTIN_CLIENT_MODULES = (
     "shelfmark.download.clients.realdebrid",
     "shelfmark.download.clients.rtorrent",
     "shelfmark.download.clients.sabnzbd",
+    "shelfmark.download.clients.torbox",
     "shelfmark.download.clients.transmission",
 )
 _builtin_client_state = {"loaded": False}

--- a/shelfmark/download/clients/settings.py
+++ b/shelfmark/download/clients/settings.py
@@ -565,6 +565,22 @@ def _test_realdebrid_connection(current_values: dict[str, Any] | None = None) ->
     return {"success": success, "message": message}
 
 
+def _test_torbox_connection(current_values: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Test the Torbox API connection using current form values."""
+    from shelfmark.core.config import config
+    from shelfmark.download.clients.torbox import TorboxClient
+
+    current_values = current_values or {}
+    api_key = _resolve_string_setting(current_values, config.get, "TORBOX_API_KEY")
+    if not api_key:
+        return {"success": False, "message": "Torbox API Key is required"}
+
+    client = TorboxClient()
+    client._api_key = api_key
+    success, message = client.test_connection()
+    return {"success": success, "message": message}
+
+
 # ==================== Download Clients Tab ====================
 
 
@@ -592,6 +608,7 @@ def prowlarr_clients_settings() -> list[SettingsField]:
                 {"value": "alldebrid", "label": "AllDebrid"},
                 {"value": "qbittorrent", "label": "qBittorrent"},
                 {"value": "realdebrid", "label": "Real-Debrid"},
+                {"value": "torbox", "label": "Torbox"},
                 {"value": "transmission", "label": "Transmission"},
                 {"value": "deluge", "label": "Deluge"},
                 {"value": "rtorrent", "label": "rTorrent"},
@@ -627,6 +644,21 @@ def prowlarr_clients_settings() -> list[SettingsField]:
             style="primary",
             callback=_test_realdebrid_connection,
             show_when={"field": "PROWLARR_TORRENT_CLIENT", "value": "realdebrid"},
+        ),
+        # --- Torbox Settings ---
+        PasswordField(
+            key="TORBOX_API_KEY",
+            label="API Key",
+            description="Torbox API key from your Torbox account settings",
+            show_when={"field": "PROWLARR_TORRENT_CLIENT", "value": "torbox"},
+        ),
+        ActionButton(
+            key="test_torbox",
+            label="Test Connection",
+            description="Verify your Torbox configuration",
+            style="primary",
+            callback=_test_torbox_connection,
+            show_when={"field": "PROWLARR_TORRENT_CLIENT", "value": "torbox"},
         ),
         # --- qBittorrent Settings ---
         TextField(

--- a/shelfmark/download/clients/torbox.py
+++ b/shelfmark/download/clients/torbox.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import shutil
 import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar, NoReturn
+from typing import TYPE_CHECKING, Any, ClassVar, NoReturn
 
 import requests
 
@@ -23,12 +24,20 @@ from shelfmark.download.clients._coercion import config_text
 from shelfmark.download.http import download_url
 from shelfmark.download.network import get_ssl_verify
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from io import BytesIO
+    from threading import Event
+
 logger = setup_logger(__name__)
 
 _API_BASE = "https://api.torbox.app/v1/api"
 _API_TIMEOUT = 30
 _STATUS_TIMEOUT = 15
 _READY_STATES = frozenset({"cached", "completed"})
+_WEBDL_READY_STATES = frozenset({"cached", "completed", "downloaded", "finished"})
+_WEBDL_ERROR_STATES = frozenset({"error", "failed", "virus"})
+_WEBDL_POLL_INTERVAL = 2
 _BOOK_EXTENSIONS = (
     ".aac", ".azw", ".azw3", ".cbr", ".cbz", ".djvu", ".doc", ".docx",
     ".epub", ".fb2", ".flac", ".lit", ".m4a", ".m4b", ".mobi", ".mp3",
@@ -214,6 +223,69 @@ class TorboxClient(DownloadClient):
         target_dir = TMP_DIR / f"torbox_{download_id}"
         return str(target_dir) if target_dir.exists() else None
 
+    def download_web_url(
+        self,
+        url: str,
+        name: str,
+        size: str = "",
+        progress_callback: Callable[[float], None] | None = None,
+        cancel_flag: Event | None = None,
+        status_callback: Callable[[str, str | None], None] | None = None,
+    ) -> BytesIO | None:
+        """Fetch a direct URL through Torbox's web-download service."""
+        if not self._api_key:
+            msg = "Torbox API key is not configured"
+            raise RuntimeError(msg)
+        if cancel_flag and cancel_flag.is_set():
+            return None
+
+        create_url = f"{_API_BASE}/webdl/createwebdownload"
+        response = requests.post(
+            create_url,
+            headers=self._auth_headers(),
+            data={"link": url, "name": name},
+            timeout=_API_TIMEOUT,
+            verify=get_ssl_verify(create_url),
+        )
+        response.raise_for_status()
+        data = self._response_data(response.json())
+        if not isinstance(data, dict):
+            msg = "Unexpected Torbox web download response"
+            _raise_type_error(msg)
+        web_id = str(data.get("webdownload_id", data.get("web_id", data.get("id", ""))))
+        if not web_id:
+            msg = "No web download ID returned from Torbox"
+            _raise_runtime_error(msg)
+
+        try:
+            while True:
+                if cancel_flag and cancel_flag.is_set():
+                    return None
+                web_download = self._get_web_download(web_id)
+                state = str(web_download.get("download_state", web_download.get("status", ""))).lower()
+                if state in _WEBDL_ERROR_STATES:
+                    msg = str(web_download.get("error") or "Torbox web download failed")
+                    _raise_runtime_error(msg)
+                if state in _WEBDL_READY_STATES:
+                    break
+                if status_callback:
+                    status_callback("resolving", "Torbox is retrieving the file")
+                time.sleep(_WEBDL_POLL_INTERVAL)
+
+            if status_callback:
+                status_callback("downloading", "Downloading via Torbox")
+            direct_url = self._request_web_download_link(web_id)
+            return download_url(
+                direct_url,
+                size,
+                progress_callback,
+                cancel_flag,
+                status_callback=status_callback,
+                referer="https://torbox.app/",
+            )
+        finally:
+            self._remove_web_download(web_id)
+
     @staticmethod
     def _response_data(payload: dict[str, Any]) -> Any:
         """Return Torbox's data envelope or surface its API error detail."""
@@ -306,6 +378,52 @@ class TorboxClient(DownloadClient):
             msg = "Torbox did not return a download link"
             _raise_runtime_error(msg)
         return data
+
+    def _get_web_download(self, web_id: str) -> dict[str, Any]:
+        url = f"{_API_BASE}/webdl/mylist"
+        response = requests.get(
+            url,
+            headers=self._auth_headers(),
+            params={"id": web_id, "bypass_cache": "true"},
+            timeout=_STATUS_TIMEOUT,
+            verify=get_ssl_verify(url),
+        )
+        response.raise_for_status()
+        data = self._response_data(response.json())
+        if isinstance(data, list):
+            data = data[0] if data else {}
+        if not isinstance(data, dict):
+            msg = "Unexpected Torbox web download status response"
+            _raise_type_error(msg)
+        return data
+
+    def _request_web_download_link(self, web_id: str) -> str:
+        url = f"{_API_BASE}/webdl/requestdl"
+        response = requests.get(
+            url,
+            params={"token": self._api_key, "web_id": web_id},
+            timeout=_API_TIMEOUT,
+            verify=get_ssl_verify(url),
+        )
+        response.raise_for_status()
+        data = self._response_data(response.json())
+        if not isinstance(data, str) or not data:
+            msg = "Torbox did not return a web download link"
+            _raise_runtime_error(msg)
+        return data
+
+    def _remove_web_download(self, web_id: str) -> None:
+        url = f"{_API_BASE}/webdl/controlwebdownload"
+        try:
+            requests.post(
+                url,
+                headers=self._auth_headers(),
+                json={"webdl_id": int(web_id), "operation": "delete"},
+                timeout=_STATUS_TIMEOUT,
+                verify=get_ssl_verify(url),
+            ).raise_for_status()
+        except (requests.exceptions.RequestException, ValueError):
+            logger.warning("Failed to delete Torbox web download %s", web_id)
 
     @staticmethod
     def _safe_filename(filename: str) -> Path:

--- a/shelfmark/download/clients/torbox.py
+++ b/shelfmark/download/clients/torbox.py
@@ -1,0 +1,315 @@
+"""Torbox debrid service client for Shelfmark."""
+
+from __future__ import annotations
+
+import shutil
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar, NoReturn
+
+import requests
+
+from shelfmark.config.env import TMP_DIR
+from shelfmark.core.config import config
+from shelfmark.core.logger import setup_logger
+from shelfmark.download.clients import (
+    DownloadClient,
+    DownloadState,
+    DownloadStatus,
+    register_client,
+)
+from shelfmark.download.clients._coercion import config_text
+from shelfmark.download.http import download_url
+from shelfmark.download.network import get_ssl_verify
+
+logger = setup_logger(__name__)
+
+_API_BASE = "https://api.torbox.app/v1/api"
+_API_TIMEOUT = 30
+_STATUS_TIMEOUT = 15
+_READY_STATES = frozenset({"cached", "completed"})
+_BOOK_EXTENSIONS = (
+    ".aac", ".azw", ".azw3", ".cbr", ".cbz", ".djvu", ".doc", ".docx",
+    ".epub", ".fb2", ".flac", ".lit", ".m4a", ".m4b", ".mobi", ".mp3",
+    ".ogg", ".opus", ".pdf", ".rtf", ".txt", ".wma",
+)
+
+
+def _raise_runtime_error(message: str) -> NoReturn:
+    raise RuntimeError(message)
+
+
+def _raise_type_error(message: str) -> NoReturn:
+    raise TypeError(message)
+
+
+@dataclass
+class _DownloadState:
+    """Internal mutable state for an in-progress Torbox download."""
+
+    torrent_id: str
+    name: str
+    target_dir: Path
+    phase: str = "uploading"
+    error_message: str | None = None
+    progress: float = 0.0
+    download_thread: threading.Thread | None = None
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+@register_client("torrent")
+class TorboxClient(DownloadClient):
+    """Download torrent content through Torbox's CDN.
+
+    API documentation: https://api.torbox.app/docs
+    """
+
+    protocol = "torrent"
+    name = "torbox"
+
+    _downloads: ClassVar[dict[str, _DownloadState]] = {}
+    _downloads_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._api_key = config_text(config.get("TORBOX_API_KEY", ""))
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}"}
+
+    @staticmethod
+    def is_configured() -> bool:
+        client = config_text(config.get("PROWLARR_TORRENT_CLIENT", ""))
+        api_key = config_text(config.get("TORBOX_API_KEY", ""))
+        return client == "torbox" and bool(api_key)
+
+    def test_connection(self) -> tuple[bool, str]:
+        """Validate credentials and confirm an active Torbox subscription."""
+        if not self._api_key:
+            return False, "Torbox API Key is required"
+        try:
+            url = f"{_API_BASE}/user/me"
+            response = requests.get(
+                url,
+                headers=self._auth_headers(),
+                timeout=_STATUS_TIMEOUT,
+                verify=get_ssl_verify(url),
+            )
+            response.raise_for_status()
+            data = self._response_data(response.json())
+            if not isinstance(data, dict):
+                msg = "Unexpected Torbox user response"
+                _raise_type_error(msg)
+            email = data.get("email", "Unknown")
+            if not data.get("is_subscribed", False) or not data.get("plan", 0):
+                return False, f"Torbox user '{email}' does not have an active subscription"
+        except (requests.exceptions.RequestException, RuntimeError, TypeError, ValueError) as error:
+            return False, f"Connection failed: {error}"
+        else:
+            return True, f"Connected to Torbox as '{email}'"
+
+    def add_download(
+        self,
+        url: str,
+        name: str,
+        category: str | None = None,
+        expected_hash: str | None = None,
+        **kwargs: object,
+    ) -> str:
+        """Add a magnet to Torbox and return its torrent ID."""
+        if not self._api_key:
+            msg = "Torbox API key is not configured"
+            raise RuntimeError(msg)
+
+        magnet_link = url
+        if not magnet_link.startswith("magnet:") and expected_hash:
+            magnet_link = f"magnet:?xt=urn:btih:{expected_hash}"
+
+        create_url = f"{_API_BASE}/torrents/createtorrent"
+        try:
+            response = requests.post(
+                create_url,
+                headers=self._auth_headers(),
+                data={"magnet": magnet_link, "name": name},
+                timeout=_API_TIMEOUT,
+                verify=get_ssl_verify(create_url),
+            )
+            response.raise_for_status()
+            data = self._response_data(response.json())
+            torrent_id = str(data.get("torrent_id", data.get("id", "")))
+            if not torrent_id:
+                msg = "No torrent ID returned from Torbox"
+                _raise_runtime_error(msg)
+
+            target_dir = TMP_DIR / f"torbox_{torrent_id}"
+            target_dir.mkdir(parents=True, exist_ok=True)
+            state = _DownloadState(torrent_id, name, target_dir, phase="waiting_torbox")
+            with self._downloads_lock:
+                self._downloads[torrent_id] = state
+        except Exception:
+            logger.exception("Failed to add magnet to Torbox")
+            raise
+        else:
+            logger.info("Added torrent to Torbox: ID %s (%s)", torrent_id, name)
+            return torrent_id
+
+    def get_status(self, download_id: str) -> DownloadStatus:
+        """Poll Torbox and start the local CDN download when ready."""
+        state = self._ensure_state(download_id)
+        with state.lock:
+            if state.phase == "error":
+                return DownloadStatus.error(state.error_message or "Torbox error")
+            if state.phase == "complete":
+                return DownloadStatus(100.0, DownloadState.COMPLETE, "Complete", True, str(state.target_dir))
+            if state.phase == "downloading_http":
+                return DownloadStatus(state.progress, DownloadState.DOWNLOADING, "Downloading files via HTTP...", False, None)
+
+        try:
+            list_url = f"{_API_BASE}/torrents/mylist"
+            response = requests.get(
+                list_url,
+                headers=self._auth_headers(),
+                params={"id": download_id, "bypass_cache": "true"},
+                timeout=_STATUS_TIMEOUT,
+                verify=get_ssl_verify(list_url),
+            )
+            response.raise_for_status()
+            torrent = self._response_data(response.json())
+            if isinstance(torrent, list):
+                torrent = torrent[0] if torrent else {}
+            if not isinstance(torrent, dict):
+                msg = "Unexpected Torbox torrent response"
+                _raise_type_error(msg)
+            return self._handle_torrent(torrent, state)
+        except Exception as error:
+            logger.exception("Error checking Torbox status for %s", download_id)
+            return DownloadStatus.error(str(error))
+
+    def remove(self, download_id: str, *, delete_files: bool = False) -> bool:
+        """Delete the torrent from Torbox and clean up local files."""
+        try:
+            url = f"{_API_BASE}/torrents/controltorrent"
+            requests.post(
+                url,
+                headers=self._auth_headers(),
+                json={"torrent_id": int(download_id), "operation": "delete"},
+                timeout=_STATUS_TIMEOUT,
+                verify=get_ssl_verify(url),
+            ).raise_for_status()
+        except (requests.exceptions.RequestException, ValueError) as error:
+            logger.warning("Failed to delete Torbox torrent %s: %s", download_id, error)
+
+        with self._downloads_lock:
+            state = self._downloads.pop(download_id, None)
+        target_dir = state.target_dir if state else TMP_DIR / f"torbox_{download_id}"
+        if target_dir.exists():
+            shutil.rmtree(target_dir, ignore_errors=True)
+        return True
+
+    def get_download_path(self, download_id: str) -> str | None:
+        with self._downloads_lock:
+            state = self._downloads.get(download_id)
+        if state and state.phase == "complete":
+            return str(state.target_dir)
+        target_dir = TMP_DIR / f"torbox_{download_id}"
+        return str(target_dir) if target_dir.exists() else None
+
+    @staticmethod
+    def _response_data(payload: dict[str, Any]) -> Any:
+        """Return Torbox's data envelope or surface its API error detail."""
+        if not payload.get("success", False):
+            msg = str(payload.get("detail") or payload.get("error") or "Torbox API error")
+            raise RuntimeError(msg)
+        return payload.get("data")
+
+    def _ensure_state(self, download_id: str) -> _DownloadState:
+        with self._downloads_lock:
+            state = self._downloads.get(download_id)
+            if state:
+                return state
+            state = _DownloadState(download_id, f"Download {download_id}", TMP_DIR / f"torbox_{download_id}", phase="waiting_torbox")
+            self._downloads[download_id] = state
+            return state
+
+    def _handle_torrent(self, torrent: dict[str, Any], state: _DownloadState) -> DownloadStatus:
+        status = str(torrent.get("download_state", "")).lower()
+        progress = float(torrent.get("progress", 0.0)) * 100.0
+        if status in _READY_STATES:
+            files = torrent.get("files", [])
+            self._maybe_start_download_thread(state, files if isinstance(files, list) else [])
+            return DownloadStatus(50.0, DownloadState.DOWNLOADING, "Torbox ready, retrieving files...", False, None)
+        if status == "paused":
+            return DownloadStatus(progress * 0.5, DownloadState.PAUSED, "Torbox torrent is paused", False, None)
+        if status == "stalled (no seeds)":
+            return DownloadStatus(progress * 0.5, DownloadState.DOWNLOADING, "Torbox torrent stalled (no seeds)", False, None)
+        return DownloadStatus(
+            progress * 0.5,
+            DownloadState.DOWNLOADING,
+            f"Torbox downloading torrent ({torrent.get('name', state.name)})",
+            False,
+            None,
+            download_speed=int(torrent.get("download_speed", 0)),
+            eta=torrent.get("eta"),
+        )
+
+    def _maybe_start_download_thread(self, state: _DownloadState, files: list[dict[str, Any]]) -> None:
+        with state.lock:
+            if state.phase in {"downloading_http", "complete"} or (state.download_thread and state.download_thread.is_alive()):
+                return
+            state.phase = "downloading_http"
+            state.download_thread = threading.Thread(target=self._download_files, args=(state, files), daemon=True)
+            state.download_thread.start()
+
+    def _download_files(self, state: _DownloadState, files: list[dict[str, Any]]) -> None:
+        try:
+            relevant = [file for file in files if str(file.get("name", "")).lower().endswith(_BOOK_EXTENSIONS)] or files
+            if not relevant:
+                msg = "No files found in Torbox torrent"
+                _raise_runtime_error(msg)
+            for index, file_info in enumerate(relevant, start=1):
+                file_id = file_info.get("id")
+                if file_id is None:
+                    msg = "Torbox torrent file is missing an ID"
+                    _raise_runtime_error(msg)
+                filename = self._safe_filename(str(file_info.get("name") or f"file_{index}"))
+                direct_url = self._request_download_link(state.torrent_id, file_id)
+                destination = state.target_dir / filename
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                buffer = download_url(direct_url, referer="https://torbox.app/")
+                if not buffer:
+                    msg = f"Failed to download from {direct_url}"
+                    _raise_runtime_error(msg)
+                with destination.open("wb") as output:
+                    output.write(buffer.getvalue())
+                with state.lock:
+                    state.progress = 50.0 + index / len(relevant) * 50.0
+            with state.lock:
+                state.phase = "complete"
+                state.progress = 100.0
+        except Exception as error:
+            logger.exception("Error downloading Torbox torrent %s", state.torrent_id)
+            with state.lock:
+                state.phase = "error"
+                state.error_message = str(error)
+
+    def _request_download_link(self, torrent_id: str, file_id: int | str) -> str:
+        url = f"{_API_BASE}/torrents/requestdl"
+        response = requests.get(
+            url,
+            params={"token": self._api_key, "torrent_id": torrent_id, "file_id": file_id},
+            timeout=_API_TIMEOUT,
+            verify=get_ssl_verify(url),
+        )
+        response.raise_for_status()
+        data = self._response_data(response.json())
+        if not isinstance(data, str) or not data:
+            msg = "Torbox did not return a download link"
+            _raise_runtime_error(msg)
+        return data
+
+    @staticmethod
+    def _safe_filename(filename: str) -> Path:
+        path = Path(filename.lstrip("/"))
+        if not path.parts or ".." in path.parts:
+            return Path(path.name or "download")
+        return path

--- a/shelfmark/release_sources/direct_download.py
+++ b/shelfmark/release_sources/direct_download.py
@@ -1,5 +1,7 @@
 """Direct download source - Anna's Archive/Libgen with fallback cascade."""
 
+from __future__ import annotations
+
 import itertools
 import json
 import re
@@ -1173,6 +1175,52 @@ def _try_download_url(
         return download_url
 
 
+def _try_torbox_aa_download(
+    book_info: BrowseRecord,
+    book_path: Path,
+    progress_callback: Callable[[float], None] | None,
+    cancel_flag: Event | None,
+    status_callback: Callable[[str, str | None], None] | None,
+) -> str | None:
+    """Try Torbox's native Anna's Archive page support before local resolution.
+
+    Torbox accepts AA's stable MD5 page and performs its own source selection.
+    Sending it a Shelfmark-resolved mirror URL is less reliable and requires the
+    local Cloudflare bypass first, defeating the purpose of this transport.
+    """
+    from shelfmark.download.clients.torbox import TorboxClient
+
+    url = f"{network.get_aa_base_url()}/md5/{book_info.id}"
+    client = TorboxClient()
+    if not client._api_key:
+        return None
+
+    try:
+        if status_callback:
+            status_callback("resolving", "Sending Anna's Archive download to Torbox")
+        data = client.download_web_url(
+            url,
+            book_info.title,
+            book_info.size or "",
+            progress_callback,
+            cancel_flag,
+            status_callback,
+        )
+        if not data:
+            return None
+        file_size = data.tell()
+        if file_size < _MIN_VALID_FILE_SIZE:
+            _raise_runtime_error(f"File too small ({file_size} bytes)")
+        data.seek(0)
+        with book_path.open("wb") as file:
+            file.write(data.getbuffer())
+    except (requests.exceptions.RequestException, RuntimeError, TypeError, ValueError, OSError) as error:
+        logger.warning("Torbox Anna's Archive download failed; trying configured sources: %s", error)
+        return None
+    else:
+        return url
+
+
 def _get_download_urls_from_welib(
     book_id: str,
     selector: network.AAMirrorSelector | None = None,
@@ -1297,6 +1345,17 @@ def _download_book(
 
     # Get enabled sources in priority order
     priority = [s for s in _get_source_priority() if s.get("enabled", True)]
+
+    if config.get("TORBOX_DIRECT_DOWNLOAD_ENABLED", False) and any(
+        source["id"].startswith("aa-") for source in priority
+    ):
+        if cancel_flag and cancel_flag.is_set():
+            return None
+        result = _try_torbox_aa_download(
+            book_info, book_path, progress_callback, cancel_flag, status_callback
+        )
+        if result:
+            return result
 
     for source_config in priority:
         source_id = source_config["id"]

--- a/tests/config/test_download_settings.py
+++ b/tests/config/test_download_settings.py
@@ -368,6 +368,20 @@ def test_download_source_settings_include_direct_download_toggle():
     assert "Add your own mirror URLs" in toggle_field.description
 
 
+def test_download_source_settings_include_torbox_direct_download_toggle():
+    from shelfmark.config.settings import download_source_settings
+
+    fields = download_source_settings()
+    toggle_field = next(
+        field
+        for field in fields
+        if getattr(field, "key", None) == "TORBOX_DIRECT_DOWNLOAD_ENABLED"
+    )
+
+    assert toggle_field.default is False
+    assert "Torbox API key" in toggle_field.description
+
+
 def test_download_source_settings_include_distant_path_language_toggle():
     from shelfmark.config.settings import download_source_settings
 

--- a/tests/download/test_torbox_client.py
+++ b/tests/download/test_torbox_client.py
@@ -106,3 +106,38 @@ def test_remove_uses_torbox_delete_operation(monkeypatch):
 
     assert client.remove("42") is True
     assert mock_post.call_args.kwargs["json"] == {"torrent_id": 42, "operation": "delete"}
+
+
+def test_download_web_url_creates_then_fetches_cdn_link(monkeypatch):
+    client = _client(monkeypatch)
+    mock_post = MagicMock(return_value=_response({"success": True, "data": {"id": 42}}))
+    mock_get = MagicMock(side_effect=[
+        _response({"success": True, "data": {"download_state": "completed"}}),
+        _response({"success": True, "data": "https://cdn.example/book"}),
+    ])
+    monkeypatch.setattr("shelfmark.download.clients.torbox.requests.post", mock_post)
+    monkeypatch.setattr("shelfmark.download.clients.torbox.requests.get", mock_get)
+    expected = BytesIO(b"contents")
+    monkeypatch.setattr("shelfmark.download.clients.torbox.download_url", lambda *args, **kwargs: expected)
+
+    assert client.download_web_url("https://source.example/book.epub", "A Book") is expected
+    assert mock_post.call_args_list[0].kwargs["data"] == {
+        "link": "https://source.example/book.epub",
+        "name": "A Book",
+    }
+    assert mock_post.call_args_list[0].args[0].endswith("/webdl/createwebdownload")
+    assert mock_get.call_args_list[1].kwargs["params"] == {"token": "api-key", "web_id": "42"}
+    assert mock_post.call_args_list[1].kwargs["json"] == {"webdl_id": 42, "operation": "delete"}
+
+
+def test_download_web_url_does_not_create_job_when_cancelled(monkeypatch):
+    from threading import Event
+
+    client = _client(monkeypatch)
+    cancel_flag = Event()
+    cancel_flag.set()
+    mock_post = MagicMock()
+    monkeypatch.setattr("shelfmark.download.clients.torbox.requests.post", mock_post)
+
+    assert client.download_web_url("https://source.example/book.epub", "A Book", cancel_flag=cancel_flag) is None
+    mock_post.assert_not_called()

--- a/tests/prowlarr/test_torbox_client.py
+++ b/tests/prowlarr/test_torbox_client.py
@@ -1,0 +1,108 @@
+"""Unit tests for the Torbox download client."""
+
+from io import BytesIO
+from unittest.mock import MagicMock
+
+from shelfmark.download.clients import DownloadState
+from shelfmark.download.clients.torbox import TorboxClient
+
+
+def _response(payload):
+    response = MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+def _client(monkeypatch):
+    config_values = {
+        "PROWLARR_TORRENT_CLIENT": "torbox",
+        "TORBOX_API_KEY": "api-key",
+    }
+    monkeypatch.setattr(
+        "shelfmark.download.clients.torbox.config.get",
+        lambda key, default="": config_values.get(key, default),
+    )
+    TorboxClient._downloads.clear()
+    return TorboxClient()
+
+
+def test_is_configured(monkeypatch):
+    assert TorboxClient.is_configured() is False
+    _client(monkeypatch)
+    assert TorboxClient.is_configured() is True
+
+
+def test_connection_accepts_active_subscription(monkeypatch):
+    client = _client(monkeypatch)
+    mock_get = MagicMock(return_value=_response({
+        "success": True,
+        "data": {"email": "reader@example.com", "is_subscribed": True, "plan": 2},
+    }))
+    monkeypatch.setattr("shelfmark.download.clients.torbox.requests.get", mock_get)
+
+    assert client.test_connection() == (True, "Connected to Torbox as 'reader@example.com'")
+    assert mock_get.call_args.kwargs["headers"] == {"Authorization": "Bearer api-key"}
+
+
+def test_add_download_posts_magnet_and_stores_state(monkeypatch):
+    client = _client(monkeypatch)
+    mock_post = MagicMock(return_value=_response({"success": True, "data": {"torrent_id": 42}}))
+    monkeypatch.setattr("shelfmark.download.clients.torbox.requests.post", mock_post)
+
+    assert client.add_download("magnet:?xt=urn:btih:hash", "A Book") == "42"
+    assert mock_post.call_args.kwargs["data"] == {
+        "magnet": "magnet:?xt=urn:btih:hash",
+        "name": "A Book",
+    }
+    assert "42" in client._downloads
+
+
+def test_get_status_starts_http_download_when_torrent_is_cached(monkeypatch):
+    client = _client(monkeypatch)
+    state = client._ensure_state("42")
+    mock_get = MagicMock(return_value=_response({
+        "success": True,
+        "data": {"download_state": "cached", "files": [{"id": 7, "name": "book.epub"}]},
+    }))
+    monkeypatch.setattr("shelfmark.download.clients.torbox.requests.get", mock_get)
+    started_with = []
+    monkeypatch.setattr(client, "_maybe_start_download_thread", lambda *args: started_with.extend(args))
+
+    status = client.get_status("42")
+
+    assert status.state == DownloadState.DOWNLOADING
+    assert status.progress == 50.0
+    assert started_with == [state, [{"id": 7, "name": "book.epub"}]]
+    assert mock_get.call_args.kwargs["params"] == {"id": "42", "bypass_cache": "true"}
+
+
+def test_download_files_requests_tokenized_link_and_filters_books(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    state = client._ensure_state("42")
+    state.target_dir = tmp_path
+    mock_get = MagicMock(return_value=_response({"success": True, "data": "https://cdn.example/book"}))
+    monkeypatch.setattr("shelfmark.download.clients.torbox.requests.get", mock_get)
+    monkeypatch.setattr(
+        "shelfmark.download.clients.torbox.download_url",
+        lambda *args, **kwargs: BytesIO(b"contents"),
+    )
+
+    client._download_files(state, [{"id": 1, "name": "cover.jpg"}, {"id": 2, "name": "book.epub"}])
+
+    assert (tmp_path / "book.epub").read_bytes() == b"contents"
+    assert not (tmp_path / "cover.jpg").exists()
+    assert mock_get.call_args.kwargs["params"] == {
+        "token": "api-key",
+        "torrent_id": "42",
+        "file_id": 2,
+    }
+    assert state.phase == "complete"
+
+
+def test_remove_uses_torbox_delete_operation(monkeypatch):
+    client = _client(monkeypatch)
+    mock_post = MagicMock(return_value=_response({"success": True, "data": None}))
+    monkeypatch.setattr("shelfmark.download.clients.torbox.requests.post", mock_post)
+
+    assert client.remove("42") is True
+    assert mock_post.call_args.kwargs["json"] == {"torrent_id": 42, "operation": "delete"}


### PR DESCRIPTION
## AI Use Notice
AI was used to co-author the changes, that were then reviewed by me. PR description was written solely by me.

## Context
Based on earlier PR #1146, here is PR to add support for using Torbox in two capacities:
1. As a torrent download client; this works almost identically to the real-debrid and alldebrid integrations from that earlier PR.
2. As a direct download enabler; this is a bit more tricky, and I recognize that it conflicts with the idea of a "direct download", but Torbox offers the feature to download contents from Anna's archive for you. This simplifies the download process and offers a faster solution that isn't reliant on any cloudflare bypass mechanism. I wanted to see if I could integrate this within another part of shelfmark, but this was the most obvious way to do it since we can leverage the existing web downloading logic around using AA.

I'm mostly creating this for my own use, but figured I would put in a PR if this is deemed to be useful for others. Thanks for creating a kick-ass project and thanks for taking the time to read this description!