### PR TITLE
Fix protection bypass cancelled by stall detection at exactly 300s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     # For building C-extensions (cffi, gevent, etc.)
     gcc \
+    g++ \
     libffi-dev \
     python3-dev \
     # For locale

--- a/shelfmark/bypass/external_bypasser.py
+++ b/shelfmark/bypass/external_bypasser.py
@@ -47,6 +47,22 @@ def _coerce_timeout_ms(value: object, default: int) -> int:
     return default
 
 
+def max_duration_seconds() -> float:
+    """Upper bound on how long get_bypassed_page() can take for one URL.
+
+    MAX_RETRY attempts at the configured read timeout, plus the exponential backoff waited
+    between them (jitter is < 1s per gap, counted as a full second to stay conservative).
+    Callers use this to declare a stall-detection grace; see shelfmark.download.activity.
+    """
+    bypasser_timeout = _coerce_timeout_ms(config.get("EXT_BYPASSER_TIMEOUT", 60000), 60000)
+    read_timeout = min((bypasser_timeout / 1000) + READ_TIMEOUT_BUFFER, MAX_READ_TIMEOUT)
+    backoff_total = sum(
+        min(BACKOFF_CAP, BACKOFF_BASE * (2 ** (attempt - 1))) + 1.0
+        for attempt in range(1, MAX_RETRY)
+    )
+    return MAX_RETRY * read_timeout + backoff_total
+
+
 def _fetch_via_bypasser(target_url: str) -> str | None:
     """Make a single request to the external bypasser service. Returns HTML or None."""
     raw_bypasser_url = _coerce_config_str(

--- a/shelfmark/bypass/internal_bypasser.py
+++ b/shelfmark/bypass/internal_bypasser.py
@@ -50,6 +50,9 @@ _LOADING_BODY_LENGTH_MAX = 50
 _PAGE_BODY_PREVIEW_CHARS = 500
 _BROWSER_START_TIMEOUT_SECONDS = 45.0
 _BYPASS_SUBPROCESS_TIMEOUT_SECONDS = 420.0
+# Same budget as the Docker helper process, applied to the in-process CDP path so both
+# branches of get() are bounded the same way.
+_IN_PROCESS_BYPASS_TIMEOUT_SECONDS = _BYPASS_SUBPROCESS_TIMEOUT_SECONDS
 _BYPASS_CHILD_ENV = "SHELFMARK_INTERNAL_BYPASSER_CHILD"
 
 # Challenge detection indicators
@@ -217,7 +220,13 @@ class _CdpWorker:
             msg = "CDP worker loop not available"
             raise RuntimeError(msg)
         future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-        return future.result(timeout=timeout)
+        try:
+            return future.result(timeout=timeout)
+        except TimeoutError:
+            # Otherwise the coroutine keeps running in the worker loop after we stop
+            # waiting, holding the browser and racing the next bypass.
+            future.cancel()
+            raise
 
 
 _CDP_WORKER = _CdpWorker()
@@ -896,7 +905,11 @@ def _run_bypass_in_current_process(url: str, retry: int, cancel_flag: Event | No
 
     if os.environ.get(_BYPASS_CHILD_ENV) == "1":
         return asyncio.run(_run_bypass())
-    return _CDP_WORKER.run(_run_bypass())
+    # Bound the wait: this path runs in-process (non-Docker installs), holds the module-wide
+    # LOCKED for its whole duration, and neither page.get() nor page.wait() has a timeout of
+    # its own. Without a deadline here a single wedged CDP session blocks every subsequent
+    # bypass in the process forever.
+    return _CDP_WORKER.run(_run_bypass(), timeout=_IN_PROCESS_BYPASS_TIMEOUT_SECONDS)
 
 
 def _store_child_bypass_state(payload: dict[str, Any]) -> None:
@@ -1254,6 +1267,16 @@ def _try_with_cached_cookies(url: str, hostname: str) -> str | None:
         logger.debug("Cached cookie retry failed for %s: %s", url, exc)
 
     return None
+
+
+def max_duration_seconds() -> float:
+    """Upper bound on how long get_bypassed_page() can take for one URL.
+
+    Both branches of get() are capped at _BYPASS_SUBPROCESS_TIMEOUT_SECONDS, and
+    get_bypassed_page() may call it twice (once, then again after a mirror/DNS rotation).
+    Callers use this to declare a stall-detection grace; see shelfmark.download.activity.
+    """
+    return 2 * _BYPASS_SUBPROCESS_TIMEOUT_SECONDS
 
 
 def get_bypassed_page(

--- a/shelfmark/download/activity.py
+++ b/shelfmark/download/activity.py
@@ -1,0 +1,81 @@
+"""Stall-detection grace signalling for long single-shot download operations.
+
+The orchestrator cancels a download after `STALL_TIMEOUT` seconds without activity, where
+"activity" means a *changed* status event or a *changed* progress value. That de-duplication
+is deliberate - a keep-alive that repeats the same payload on a timer proves nothing about
+whether the operation is still making progress, so letting it refresh the stall clock would
+make a genuinely wedged download immortal.
+
+Operations that legitimately take longer than `STALL_TIMEOUT` but cannot report incremental
+progress therefore declare an explicit upper bound up front instead:
+
+    request_activity_grace(status_callback, my_worst_case_seconds)
+    try:
+        ...one long blocking call...
+    finally:
+        release_activity_grace(status_callback)
+
+The grace is a single absolute deadline. It is never extended, so the operation still dies
+if it overruns its own declared budget - just at *its* bound rather than at a global 300s.
+
+The signal rides on the existing `status_callback` channel using a sentinel status, which
+avoids threading a new parameter through every handler, post-processor and output module.
+`shelfmark.download.orchestrator`'s per-task `status_callback` closure intercepts the
+sentinel and never forwards it to `update_download_status`.
+
+Adopters should be operations that yield to the gevent hub while blocking (`requests`,
+patched `subprocess`). An operation that blocks the hub outright - `shutil.copy2`, sqlite -
+will still be killed by the gunicorn worker timeout regardless of any grace, and must go
+through `shelfmark.download.fs.run_blocking_io` first.
+
+Current adopters: `shelfmark.download.http.html_get_page` (protection bypass).
+Candidates: `download.clients.base_handler._wait_for_completed_path`, archive extraction in
+`download.postprocess.scan`, large-file copies in `download.outputs.folder`, email/BookLore
+uploads, and the Anna's Archive countdown in `release_sources.direct_download` (which today
+refreshes the stall clock on every tick of a loop that proves nothing about the remote).
+"""
+
+from collections.abc import Callable
+
+# Not a QueueStatus value, so `update_download_status` would reject it anyway; the
+# orchestrator's status_callback intercepts it before that point.
+ACTIVITY_GRACE_STATUS = "__activity_grace__"
+
+StatusCallback = Callable[[str, str | None], None]
+
+# A status_callback is caller-supplied and may raise; a failed liveness hint must never
+# break the operation it was protecting. Mirrors http._STATUS_CALLBACK_ERRORS.
+_CALLBACK_ERRORS = (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError)
+
+
+def request_activity_grace(status_callback: StatusCallback | None, seconds: float) -> None:
+    """Ask the orchestrator to suppress stall detection for up to `seconds` from now."""
+    _emit(status_callback, seconds)
+
+
+def release_activity_grace(status_callback: StatusCallback | None) -> None:
+    """Drop any outstanding grace and count now as activity."""
+    _emit(status_callback, 0)
+
+
+def parse_activity_grace(status: str, message: str | None) -> float | None:
+    """Return the requested grace in seconds, or None if this is not a grace event.
+
+    Never raises: a malformed sentinel is treated as "not a grace event" so a bad emitter
+    cannot take down the status pipeline.
+    """
+    if status != ACTIVITY_GRACE_STATUS:
+        return None
+    try:
+        return max(float(message or 0), 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _emit(status_callback: StatusCallback | None, seconds: float) -> None:
+    if status_callback is None:
+        return
+    try:
+        status_callback(ACTIVITY_GRACE_STATUS, str(float(seconds)))
+    except _CALLBACK_ERRORS:
+        return

--- a/shelfmark/download/activity.py
+++ b/shelfmark/download/activity.py
@@ -68,7 +68,7 @@ def parse_activity_grace(status: str, message: str | None) -> float | None:
         return None
     try:
         return max(float(message or 0), 0.0)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return 0.0
 
 

--- a/shelfmark/download/http.py
+++ b/shelfmark/download/http.py
@@ -4,7 +4,6 @@ import random
 import time
 from http import HTTPStatus
 from io import BytesIO
-from threading import Event, Thread
 from typing import TYPE_CHECKING, NoReturn
 from urllib.parse import urljoin, urlparse
 
@@ -16,10 +15,12 @@ from shelfmark.core.config import config as app_config
 from shelfmark.core.logger import setup_logger
 from shelfmark.core.request_helpers import coerce_bool, normalize_positive_int
 from shelfmark.download import network
+from shelfmark.download.activity import release_activity_grace, request_activity_grace
 from shelfmark.download.network import get_proxies, get_ssl_verify
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from threading import Event
     from types import ModuleType
 
 logger = setup_logger(__name__)
@@ -34,6 +35,9 @@ _HTTP_STATUS_RANGE_NOT_SATISFIABLE = HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE
 _HTTP_STATUS_PARTIAL_CONTENT = HTTPStatus.PARTIAL_CONTENT
 _HTTP_STATUS_NON_RETRYABLE = (_HTTP_STATUS_FORBIDDEN, _HTTP_STATUS_NOT_FOUND)
 _STATUS_CALLBACK_ERRORS = (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError)
+# Added on top of the active bypasser's own budget so it reports its real failure before
+# stall detection cancels the download.
+_BYPASS_GRACE_SLACK_SECONDS = 30.0
 _BYPASSER_ERRORS = (
     AttributeError,
     BypassCancelledError,
@@ -97,6 +101,19 @@ def _is_using_external_bypasser() -> bool:
 def _is_cf_bypass_enabled() -> bool:
     """Check if Cloudflare bypass is enabled."""
     return coerce_bool(app_config.get("USE_CF_BYPASS", True))
+
+
+def _bypass_grace_seconds() -> float:
+    """How long a bypass may block before stall detection should give up on it.
+
+    Each bypasser knows its own retry/timeout budget, so ask the active one rather than
+    duplicating the arithmetic here. The slack keeps the bypasser's own deadline expiring
+    first, so the user sees its real error instead of a generic "Download stalled".
+    """
+    bypasser = (
+        _get_external_bypasser() if _is_using_external_bypasser() else _get_internal_bypasser()
+    )
+    return bypasser.max_duration_seconds() + _BYPASS_GRACE_SLACK_SECONDS
 
 
 def get_bypassed_page(
@@ -273,34 +290,27 @@ def html_get_page(
             if use_bypasser_now and _is_cf_bypass_enabled():
                 if status_callback:
                     status_callback("resolving", "Bypassing protection...")
-                heartbeat_stop = Event()
-                heartbeat_thread: Thread | None = None
-                if status_callback:
-
-                    def _heartbeat() -> None:
-                        # Keep the download "alive" during long bypass operations so the orchestrator
-                        # doesn't flag it as stalled.
-                        if cancel_flag and cancel_flag.is_set():
-                            return
-                        try:
-                            status_callback("resolving", "Bypassing protection...")
-                        except _STATUS_CALLBACK_ERRORS:
-                            return
-
-                    heartbeat_thread = Thread(
-                        target=_heartbeat, daemon=True, name="BypassHeartbeat"
-                    )
-                    heartbeat_thread.start()
                 try:
+                    # A bypass is one long blocking call with no incremental progress, so
+                    # tell the orchestrator up front how long it may legitimately take
+                    # instead of trying to fake activity while it runs. Inside the try so a
+                    # bypasser that fails to load is still reported as a bypasser error.
+                    request_activity_grace(status_callback, _bypass_grace_seconds())
                     result = get_bypassed_page(current_url, selector, cancel_flag)
                     return _result(result or "", current_url)
                 except _BYPASSER_ERRORS as e:
                     logger.warning("Bypasser error: %s: %s", type(e).__name__, e)
+                    # Surface the real reason. Without this the caller only sees an empty
+                    # page and the download dies with a generic failure, hiding e.g. a
+                    # FlareSolverr 500 behind a silent wait.
+                    if status_callback and not isinstance(e, BypassCancelledError):
+                        try:
+                            status_callback("error", f"Bypass failed: {type(e).__name__}: {e}")
+                        except _STATUS_CALLBACK_ERRORS:
+                            logger.debug("Bypass error status callback failed", exc_info=True)
                     return _result("", current_url)
                 finally:
-                    heartbeat_stop.set()
-                    if heartbeat_thread:
-                        heartbeat_thread.join(timeout=1)
+                    release_activity_grace(status_callback)
 
             logger.debug("GET: %s", current_url)
 

--- a/shelfmark/download/orchestrator.py
+++ b/shelfmark/download/orchestrator.py
@@ -12,7 +12,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from email.utils import parseaddr
 from pathlib import Path
 from threading import Event, Lock
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from shelfmark.core.config import config
 from shelfmark.core.logger import setup_logger
@@ -24,6 +24,7 @@ from shelfmark.core.request_helpers import (
 )
 from shelfmark.core.utils import is_audiobook as check_audiobook
 from shelfmark.core.utils import transform_cover_url
+from shelfmark.download.activity import parse_activity_grace
 from shelfmark.download.fs import run_blocking_io
 from shelfmark.download.postprocess.pipeline import is_torrent_source, safe_cleanup_path
 from shelfmark.download.postprocess.router import post_process_download
@@ -32,6 +33,9 @@ from shelfmark.release_sources import (
     get_source,
     get_source_display_name,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 logger = setup_logger(__name__)
 _RNG = random.SystemRandom()
@@ -65,7 +69,16 @@ _last_progress_value: dict[str, float] = {}
 # De-duplicate status updates (keep-alive updates shouldn't spam clients)
 _last_status_event: dict[str, tuple[str, str | None]] = {}
 STALL_TIMEOUT = 300  # 5 minutes without progress/status update = stalled
+# Absolute deadlines (time.time()) until which stall detection is suppressed for a task.
+# Long single-shot operations (protection bypass, etc.) declare their own upper bound via
+# `shelfmark.download.activity` instead of faking progress. See set_activity_grace().
+_activity_grace: dict[str, float] = {}
+# A caller cannot buy immortality: the largest grace any operation may request. Must stay
+# above the largest budget any caller can declare (see http._bypass_grace_seconds).
+_MAX_ACTIVITY_GRACE_SECONDS = 960.0
 COORDINATOR_LOOP_ERROR_RETRY_DELAY = 1.0
+# Ceiling for the exponential backoff applied to repeated coordinator loop failures.
+_COORDINATOR_LOOP_ERROR_MAX_DELAY = 30.0
 _PROGRESS_BROADCAST_START_PERCENT = 1
 _PROGRESS_BROADCAST_COMPLETE_PERCENT = 99
 _PROGRESS_BROADCAST_MIN_DELTA = 10
@@ -649,6 +662,17 @@ def _download_task(task_id: str, cancel_flag: Event) -> str | None:
         update_download_progress(task_id, progress)
 
     def status_callback(status: str, message: str | None = None) -> None:
+        # Liveness hint from a long single-shot operation, not a user-visible status.
+        # Handled here so it never reaches update_download_status (which dedupes status
+        # transitions on purpose). See shelfmark.download.activity.
+        grace = parse_activity_grace(status, message)
+        if grace is not None:
+            if grace > 0:
+                set_activity_grace(task_id, grace)
+            else:
+                clear_activity_grace(task_id)
+            return
+
         status_key = status.lower()
         if status_key == "error":
             _capture_task_error(
@@ -886,6 +910,7 @@ def _cleanup_progress_tracking(task_id: str) -> None:
         _last_activity.pop(task_id, None)
         _last_progress_value.pop(task_id, None)
         _last_status_event.pop(task_id, None)
+        _activity_grace.pop(task_id, None)
 
 
 def _finalize_download_failure(task_id: str) -> None:
@@ -933,6 +958,66 @@ def _process_single_download(task_id: str, cancel_flag: Event) -> None:
         ws_manager.broadcast_status_update(queue_status())
 
 
+def set_activity_grace(book_id: str, seconds: float) -> None:
+    """Suppress stall detection for `book_id` for up to `seconds` from now.
+
+    For long single-shot operations that cannot report incremental progress (protection
+    bypass being the motivating case). The grace is a single absolute deadline computed
+    once, so it cannot be extended into immortality by a keep-alive that carries no real
+    liveness information - an operation that hangs forever is still cancelled once its
+    declared budget expires.
+
+    Deliberately touches neither the queue nor the WebSocket: this is a liveness
+    assertion, not a user-visible status transition.
+    """
+    grace = _config_float(seconds, 0.0)
+    grace = min(max(grace, 0.0), _MAX_ACTIVITY_GRACE_SECONDS)
+    with _progress_lock:
+        _activity_grace[book_id] = time.time() + grace
+
+
+def clear_activity_grace(book_id: str) -> None:
+    """Drop any activity grace for `book_id` and count this moment as activity.
+
+    Resetting `_last_activity` means a nested or abandoned grace degrades to a fresh
+    full STALL_TIMEOUT window rather than an immediate stall.
+    """
+    with _progress_lock:
+        _activity_grace.pop(book_id, None)
+        _last_activity[book_id] = time.time()
+
+
+def _find_stalled_tasks(task_ids: Iterable[str], now: float) -> list[str]:
+    """Return the task ids with no activity inside STALL_TIMEOUT and no active grace.
+
+    Holds `_progress_lock` for dict reads only - never call into `book_queue` from here,
+    see _cancel_stalled_task().
+    """
+    stalled: list[str] = []
+    with _progress_lock:
+        for task_id in task_ids:
+            last_active = _last_activity.get(task_id, now)
+            deadline = max(last_active + STALL_TIMEOUT, _activity_grace.get(task_id, 0.0))
+            if now > deadline:
+                stalled.append(task_id)
+    return stalled
+
+
+def _cancel_stalled_task(task_id: str) -> None:
+    """Cancel a stalled download.
+
+    Must be called WITHOUT `_progress_lock` held. `book_queue.cancel_download` runs the
+    terminal-status hooks, which reach a sqlite write that gevent does not patch; holding
+    the progress lock across that blocks the hub and every other download worker.
+    """
+    logger.warning("Download stalled for %s, cancelling", task_id)
+    book_queue.cancel_download(task_id)
+    book_queue.update_status_message(
+        task_id,
+        f"Download stalled (no activity for {STALL_TIMEOUT}s)",
+    )
+
+
 def concurrent_download_loop() -> None:
     """Run the main concurrent download coordinator."""
     max_workers = normalize_positive_int(config.MAX_CONCURRENT_DOWNLOADS) or 1
@@ -942,6 +1027,7 @@ def concurrent_download_loop() -> None:
     with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="Download") as executor:
         active_futures: dict[Future, tuple[str, Event]] = {}  # Track active download futures
         stalled_tasks: set[str] = set()  # Track tasks already cancelled due to stall
+        consecutive_errors = 0
 
         while True:
             try:
@@ -992,19 +1078,14 @@ def concurrent_download_loop() -> None:
 
                 # Check for stalled downloads (no activity in STALL_TIMEOUT seconds)
                 current_time = time.time()
-                with _progress_lock:
-                    for _future, (task_id, _cancel_flag) in list(active_futures.items()):
-                        if task_id in stalled_tasks:
-                            continue
-                        last_active = _last_activity.get(task_id, current_time)
-                        if current_time - last_active > STALL_TIMEOUT:
-                            logger.warning("Download stalled for %s, cancelling", task_id)
-                            book_queue.cancel_download(task_id)
-                            book_queue.update_status_message(
-                                task_id,
-                                f"Download stalled (no activity for {STALL_TIMEOUT}s)",
-                            )
-                            stalled_tasks.add(task_id)
+                candidates = [
+                    task_id
+                    for _future, (task_id, _cancel_flag) in list(active_futures.items())
+                    if task_id not in stalled_tasks
+                ]
+                for task_id in _find_stalled_tasks(candidates, current_time):
+                    _cancel_stalled_task(task_id)
+                    stalled_tasks.add(task_id)
 
                 # Start new downloads if we have capacity
                 while len(active_futures) < max_workers:
@@ -1027,9 +1108,24 @@ def concurrent_download_loop() -> None:
 
                 # Brief sleep to prevent busy waiting
                 time.sleep(main_loop_sleep_time)
-            except (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError) as e:
+                consecutive_errors = 0
+            # This loop is the only thing driving the download queue; if it exits, nothing
+            # is ever picked up again and the app looks healthy while doing nothing (#823,
+            # #1166). A narrow exception list let gevent's LoopExit and friends through, so
+            # catch everything short of BaseException - GreenletExit and gevent.Timeout must
+            # still propagate, and the tests' loop-stopping sentinels derive from
+            # BaseException for exactly this reason.
+            except Exception as e:  # noqa: BLE001 - coordinator loop must never die
+                consecutive_errors += 1
                 logger.error_trace("Download coordinator loop error: %s", e)
-                time.sleep(COORDINATOR_LOOP_ERROR_RETRY_DELAY)
+                # Back off when the failure is persistent so we don't spin at 1Hz forever,
+                # but keep the first delay unchanged for a normal transient blip.
+                time.sleep(
+                    min(
+                        COORDINATOR_LOOP_ERROR_RETRY_DELAY * 2 ** min(consecutive_errors - 1, 5),
+                        _COORDINATOR_LOOP_ERROR_MAX_DELAY,
+                    )
+                )
 
 
 # Download coordinator thread (started explicitly via start())

--- a/tests/bypass/test_external_bypasser.py
+++ b/tests/bypass/test_external_bypasser.py
@@ -101,3 +101,36 @@ def test_get_bypassed_page_retries_and_rotates_selector_between_attempts(monkeyp
     ]
     assert selector.rotate_calls == 1
     assert sleeps == [1.0]
+
+
+def _stub_ext_bypasser_timeout(monkeypatch, external_bypasser, value: int) -> None:
+    """Override only EXT_BYPASSER_TIMEOUT on the shared config singleton."""
+    real_get = external_bypasser.config.get
+    monkeypatch.setattr(
+        external_bypasser.config,
+        "get",
+        lambda key, default="": value if key == "EXT_BYPASSER_TIMEOUT" else real_get(key, default),
+    )
+
+
+def test_max_duration_seconds_covers_every_attempt_and_backoff(monkeypatch):
+    """The declared budget must not undercut what get_bypassed_page() can actually take."""
+    import shelfmark.bypass.external_bypasser as external_bypasser
+
+    _stub_ext_bypasser_timeout(monkeypatch, external_bypasser, 60000)
+
+    budget = external_bypasser.max_duration_seconds()
+
+    # 5 attempts at min(60 + 15, 120) = 75s, plus the 1+2+4+8 backoff and its jitter.
+    assert budget == 5 * 75.0 + (1 + 1) + (2 + 1) + (4 + 1) + (8 + 1)
+
+
+def test_max_duration_seconds_respects_the_read_timeout_ceiling(monkeypatch):
+    import shelfmark.bypass.external_bypasser as external_bypasser
+
+    _stub_ext_bypasser_timeout(monkeypatch, external_bypasser, 300000)
+
+    budget = external_bypasser.max_duration_seconds()
+
+    # 300s + 15s buffer is clamped to MAX_READ_TIMEOUT, not used raw.
+    assert budget == 5 * external_bypasser.MAX_READ_TIMEOUT + 19.0

--- a/tests/bypass/test_internal_bypasser.py
+++ b/tests/bypass/test_internal_bypasser.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 
 import pytest
 
@@ -430,3 +431,54 @@ def test_get_bypassed_page_retries_next_mirror_after_runtime_error(monkeypatch):
         "https://mirror-one.example/book",
         "https://mirror-two.example/book",
     ]
+
+
+def test_max_duration_seconds_allows_for_a_mirror_rotation_retry():
+    """get_bypassed_page() may call get() twice, so the budget must cover both."""
+    import shelfmark.bypass.internal_bypasser as internal_bypasser
+
+    assert internal_bypasser.max_duration_seconds() == (
+        2 * internal_bypasser._BYPASS_SUBPROCESS_TIMEOUT_SECONDS
+    )
+
+
+def test_cdp_worker_run_times_out_and_cancels_the_orphaned_coroutine(monkeypatch):
+    """A wedged in-process bypass must not block forever holding LOCKED.
+
+    Regression guard: _CDP_WORKER.run() used to wait with timeout=None, so one hung CDP
+    session blocked every subsequent bypass in the process indefinitely.
+    """
+    import shelfmark.bypass.internal_bypasser as internal_bypasser
+
+    started = threading.Event()
+
+    async def _never_finish():
+        started.set()
+        await asyncio.Event().wait()
+
+    coro = _never_finish()
+    with pytest.raises(TimeoutError):
+        internal_bypasser._CDP_WORKER.run(coro, timeout=0.05)
+
+    assert started.is_set(), "coroutine should have been scheduled before timing out"
+
+
+def test_run_bypass_in_current_process_bounds_its_wait(monkeypatch):
+    """The in-process path passes a deadline rather than waiting forever."""
+    import shelfmark.bypass.internal_bypasser as internal_bypasser
+
+    observed: dict[str, float | None] = {}
+
+    class _FakeWorker:
+        def run(self, coro, timeout=None):
+            observed["timeout"] = timeout
+            coro.close()
+            return "html"
+
+    monkeypatch.setattr(internal_bypasser, "_CDP_WORKER", _FakeWorker())
+    monkeypatch.delenv("SHELFMARK_INTERNAL_BYPASSER_CHILD", raising=False)
+
+    result = internal_bypasser._run_bypass_in_current_process("https://example.com", 1)
+
+    assert result == "html"
+    assert observed["timeout"] == internal_bypasser._IN_PROCESS_BYPASS_TIMEOUT_SECONDS

--- a/tests/download/test_activity.py
+++ b/tests/download/test_activity.py
@@ -1,0 +1,61 @@
+"""Tests for the stall-detection activity grace signalling."""
+
+import pytest
+
+from shelfmark.core.models import QueueStatus
+from shelfmark.download.activity import (
+    ACTIVITY_GRACE_STATUS,
+    parse_activity_grace,
+    release_activity_grace,
+    request_activity_grace,
+)
+
+
+def test_request_and_parse_round_trip():
+    calls: list[tuple[str, str | None]] = []
+    request_activity_grace(lambda status, message: calls.append((status, message)), 330)
+
+    assert len(calls) == 1
+    assert parse_activity_grace(*calls[0]) == 330.0
+
+
+def test_release_emits_zero_grace():
+    calls: list[tuple[str, str | None]] = []
+    release_activity_grace(lambda status, message: calls.append((status, message)))
+
+    assert parse_activity_grace(*calls[0]) == 0.0
+
+
+def test_parse_returns_none_for_real_status_events():
+    assert parse_activity_grace("resolving", "Bypassing protection...") is None
+    assert parse_activity_grace("downloading", None) is None
+
+
+@pytest.mark.parametrize("status", [s.value for s in QueueStatus])
+def test_sentinel_cannot_collide_with_a_queue_status(status):
+    """The sentinel must never be mistaken for a real status, or vice versa."""
+    assert status != ACTIVITY_GRACE_STATUS
+    assert parse_activity_grace(status, "anything") is None
+
+
+def test_parse_tolerates_a_malformed_sentinel():
+    """A bad emitter must not take down the status pipeline."""
+    assert parse_activity_grace(ACTIVITY_GRACE_STATUS, "not-a-number") == 0.0
+    assert parse_activity_grace(ACTIVITY_GRACE_STATUS, None) == 0.0
+
+
+def test_parse_clamps_negative_grace():
+    assert parse_activity_grace(ACTIVITY_GRACE_STATUS, "-5") == 0.0
+
+
+def test_emitters_are_noops_without_a_callback():
+    request_activity_grace(None, 30)
+    release_activity_grace(None)
+
+
+def test_emitters_swallow_a_raising_callback():
+    def boom(_status: str, _message: str | None) -> None:
+        raise RuntimeError("callback failed")
+
+    request_activity_grace(boom, 30)
+    release_activity_grace(boom)

--- a/tests/download/test_http_bypasser_fallbacks.py
+++ b/tests/download/test_http_bypasser_fallbacks.py
@@ -11,22 +11,13 @@ class _FakeResponse:
         self.url = url
 
 
-class _ImmediateThread:
-    def __init__(self, *args, **kwargs) -> None:
-        self._target = kwargs["target"]
-
-    def start(self) -> None:
-        self._target()
-
-    def join(self, timeout: float | None = None) -> None:
-        del timeout
-
-
-def test_html_get_page_ignores_heartbeat_callback_failure(monkeypatch):
+def test_html_get_page_ignores_status_callback_failure(monkeypatch):
+    """A raising status_callback must not break the bypass it was reporting on."""
     import shelfmark.download.http as http
+    from shelfmark.download.activity import ACTIVITY_GRACE_STATUS
 
     monkeypatch.setattr(http, "_is_cf_bypass_enabled", lambda: True)
-    monkeypatch.setattr(http, "Thread", _ImmediateThread)
+    monkeypatch.setattr(http, "_bypass_grace_seconds", lambda: 330.0)
     monkeypatch.setattr(http, "get_bypassed_page", lambda *_args, **_kwargs: "OK")
 
     calls: list[tuple[str, str | None]] = []
@@ -46,8 +37,90 @@ def test_html_get_page_ignores_heartbeat_callback_failure(monkeypatch):
     assert html == "OK"
     assert calls == [
         ("resolving", "Bypassing protection..."),
-        ("resolving", "Bypassing protection..."),
+        (ACTIVITY_GRACE_STATUS, "330.0"),
+        (ACTIVITY_GRACE_STATUS, "0.0"),
     ]
+
+
+def test_html_get_page_requests_and_releases_activity_grace(monkeypatch):
+    """The bypass declares its budget before blocking and releases it afterwards."""
+    import shelfmark.download.http as http
+    from shelfmark.download.activity import ACTIVITY_GRACE_STATUS
+
+    monkeypatch.setattr(http, "_is_cf_bypass_enabled", lambda: True)
+    monkeypatch.setattr(http, "_bypass_grace_seconds", lambda: 424.0)
+
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_bypass(*_args, **_kwargs):
+        # The grace must already be in place before the long blocking call starts.
+        assert calls[-1] == (ACTIVITY_GRACE_STATUS, "424.0")
+        return "OK"
+
+    monkeypatch.setattr(http, "get_bypassed_page", fake_bypass)
+
+    html = http.html_get_page(
+        "https://example.com",
+        retry=1,
+        use_bypasser=True,
+        status_callback=lambda status, message: calls.append((status, message)),
+    )
+
+    assert html == "OK"
+    assert calls[-1] == (ACTIVITY_GRACE_STATUS, "0.0")
+
+
+def test_html_get_page_releases_grace_and_reports_error_when_bypasser_fails(monkeypatch):
+    """A failing bypasser surfaces its real error instead of a silent empty result."""
+    import shelfmark.download.http as http
+    from shelfmark.download.activity import ACTIVITY_GRACE_STATUS
+
+    monkeypatch.setattr(http, "_is_cf_bypass_enabled", lambda: True)
+    monkeypatch.setattr(http, "_bypass_grace_seconds", lambda: 100.0)
+
+    def failing_bypasser(*_args, **_kwargs):
+        raise requests.exceptions.RequestException("500 Server Error")
+
+    monkeypatch.setattr(http, "get_bypassed_page", failing_bypasser)
+
+    calls: list[tuple[str, str | None]] = []
+    html = http.html_get_page(
+        "https://example.com",
+        retry=1,
+        use_bypasser=True,
+        status_callback=lambda status, message: calls.append((status, message)),
+    )
+
+    assert html == ""
+    errors = [message for status, message in calls if status == "error"]
+    assert len(errors) == 1
+    assert "500 Server Error" in (errors[0] or "")
+    # The grace is always released, even on the failure path.
+    assert calls[-1] == (ACTIVITY_GRACE_STATUS, "0.0")
+
+
+def test_html_get_page_does_not_report_error_when_bypass_is_cancelled(monkeypatch):
+    """Cancellation is a user action, not a failure worth surfacing as an error."""
+    import shelfmark.download.http as http
+
+    monkeypatch.setattr(http, "_is_cf_bypass_enabled", lambda: True)
+    monkeypatch.setattr(http, "_bypass_grace_seconds", lambda: 100.0)
+
+    def cancelled_bypasser(*_args, **_kwargs):
+        raise BypassCancelledError("Bypass cancelled")
+
+    monkeypatch.setattr(http, "get_bypassed_page", cancelled_bypasser)
+
+    calls: list[tuple[str, str | None]] = []
+    html = http.html_get_page(
+        "https://example.com",
+        retry=1,
+        use_bypasser=True,
+        status_callback=lambda status, message: calls.append((status, message)),
+    )
+
+    assert html == ""
+    assert [status for status, _message in calls if status == "error"] == []
 
 
 def test_html_get_page_returns_empty_on_bypass_cancellation(monkeypatch):

--- a/tests/download/test_orchestrator_lifecycle.py
+++ b/tests/download/test_orchestrator_lifecycle.py
@@ -9,6 +9,10 @@ class _StopLoop(BaseException):
     """Sentinel used to stop the infinite coordinator loop during tests."""
 
 
+class _UnexpectedCall(BaseException):
+    """Guard-rail failure that the coordinator's `except Exception` must not swallow."""
+
+
 class _FakeExecutor:
     def __init__(self, *args, **kwargs) -> None:
         self.args = args
@@ -21,7 +25,7 @@ class _FakeExecutor:
         return False
 
     def submit(self, *args, **kwargs):  # pragma: no cover - not expected in these tests
-        raise AssertionError("submit() should not be called in this test")
+        raise _UnexpectedCall("submit() should not be called in this test")
 
 
 class _StopCoordinator(BaseException):
@@ -68,6 +72,69 @@ def test_concurrent_download_loop_logs_and_recovers_after_loop_error(monkeypatch
     ]
 
 
+def test_concurrent_download_loop_survives_exceptions_outside_the_legacy_list(monkeypatch):
+    """Regression for #823/#1166: the coordinator must not die on an unlisted exception.
+
+    `gevent.exceptions.LoopExit` and `StopIteration` are Exceptions that the old narrow
+    except tuple let through, silently killing the only thread that drives the queue.
+    """
+    import shelfmark.download.orchestrator as orchestrator
+
+    raised: list[type[BaseException]] = []
+    escapes = [StopIteration, ZeroDivisionError, KeyboardInterrupt]
+
+    def fake_get_next():
+        if escapes:
+            exc = escapes.pop(0)
+            if exc is KeyboardInterrupt:
+                # BaseException: must still propagate and stop the loop.
+                raise KeyboardInterrupt
+            raised.append(exc)
+            raise exc("boom")
+        return None
+
+    mock_queue = MagicMock()
+    mock_queue.get_next.side_effect = fake_get_next
+
+    monkeypatch.setattr(orchestrator, "book_queue", mock_queue)
+    monkeypatch.setattr(orchestrator, "ThreadPoolExecutor", _FakeExecutor)
+    monkeypatch.setattr(orchestrator.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(orchestrator.logger, "error_trace", MagicMock())
+
+    with pytest.raises(KeyboardInterrupt):
+        orchestrator.concurrent_download_loop()
+
+    assert raised == [StopIteration, ZeroDivisionError]
+
+
+def test_concurrent_download_loop_backs_off_on_repeated_errors(monkeypatch):
+    """A persistent failure must not spin the loop at 1Hz forever."""
+    import shelfmark.download.orchestrator as orchestrator
+
+    sleep_delays: list[float] = []
+
+    def fake_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+        if len(sleep_delays) >= 4:
+            raise _StopLoop()
+
+    mock_queue = MagicMock()
+    mock_queue.get_next.side_effect = RuntimeError("persistent boom")
+
+    monkeypatch.setattr(orchestrator, "book_queue", mock_queue)
+    monkeypatch.setattr(orchestrator, "ThreadPoolExecutor", _FakeExecutor)
+    monkeypatch.setattr(orchestrator.time, "sleep", fake_sleep)
+    monkeypatch.setattr(orchestrator.logger, "error_trace", MagicMock())
+
+    with pytest.raises(_StopLoop):
+        orchestrator.concurrent_download_loop()
+
+    base = orchestrator.COORDINATOR_LOOP_ERROR_RETRY_DELAY
+    # First delay stays unchanged for a normal transient blip, then doubles.
+    assert sleep_delays == [base, base * 2, base * 4, base * 8]
+    assert max(sleep_delays) <= orchestrator._COORDINATOR_LOOP_ERROR_MAX_DELAY
+
+
 def test_concurrent_download_loop_recovers_and_processes_task_after_transient_loop_error(
     monkeypatch,
 ):
@@ -91,13 +158,16 @@ def test_concurrent_download_loop_recovers_and_processes_task_after_transient_lo
                 raise _StopCoordinator()
             return None
 
+        # These raise _UnexpectedCall rather than AssertionError because the coordinator
+        # loop catches Exception: an AssertionError here would be swallowed and logged,
+        # letting the test pass vacuously instead of reporting the unexpected call.
         def cancel_download(self, task_id: str) -> None:  # pragma: no cover - unused
-            raise AssertionError(f"cancel_download unexpectedly called for {task_id}")
+            raise _UnexpectedCall(f"cancel_download unexpectedly called for {task_id}")
 
         def update_status_message(
             self, task_id: str, message: str
         ) -> None:  # pragma: no cover - unused
-            raise AssertionError(
+            raise _UnexpectedCall(
                 f"update_status_message unexpectedly called for {task_id}: {message}"
             )
 

--- a/tests/download/test_orchestrator_stall.py
+++ b/tests/download/test_orchestrator_stall.py
@@ -1,0 +1,294 @@
+"""Tests for stall detection and the activity-grace window.
+
+Covers the regression behind issue #1001: a protection bypass is a single long blocking
+call that emits no changing status or progress, so it used to be cancelled at exactly
+STALL_TIMEOUT even though the bypasser itself was still working.
+"""
+
+from unittest.mock import MagicMock
+
+import requests
+
+
+def _stub_ext_bypasser_timeout(monkeypatch, external_bypasser, value: int) -> None:
+    """Override only EXT_BYPASSER_TIMEOUT.
+
+    `external_bypasser.config` is the shared config singleton, so a blanket `get` stub
+    also answers unrelated lookups (DNS setup, etc.) with the wrong value.
+    """
+    real_get = external_bypasser.config.get
+    monkeypatch.setattr(
+        external_bypasser.config,
+        "get",
+        lambda key, default="": value if key == "EXT_BYPASSER_TIMEOUT" else real_get(key, default),
+    )
+
+
+def _reset(orchestrator) -> None:
+    orchestrator._last_activity.clear()
+    orchestrator._last_progress_value.clear()
+    orchestrator._last_status_event.clear()
+    orchestrator._activity_grace.clear()
+
+
+def test_find_stalled_tasks_flags_task_past_stall_timeout():
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+    orchestrator._last_activity["book"] = 1000.0
+    now = 1000.0 + orchestrator.STALL_TIMEOUT + 1
+
+    assert orchestrator._find_stalled_tasks(["book"], now) == ["book"]
+
+
+def test_find_stalled_tasks_ignores_task_within_stall_timeout():
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+    orchestrator._last_activity["book"] = 1000.0
+    now = 1000.0 + orchestrator.STALL_TIMEOUT - 1
+
+    assert orchestrator._find_stalled_tasks(["book"], now) == []
+
+
+def test_find_stalled_tasks_ignores_unknown_task():
+    """A task with no recorded activity yet is not considered stalled."""
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+
+    assert orchestrator._find_stalled_tasks(["never-seen"], 99999.0) == []
+
+
+def test_activity_grace_suppresses_stall_until_its_deadline(monkeypatch):
+    """A bypass that legitimately outlives STALL_TIMEOUT is not cancelled."""
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+    monkeypatch.setattr(orchestrator.time, "time", lambda: 1000.0)
+    orchestrator._last_activity["book"] = 1000.0
+    orchestrator.set_activity_grace("book", 400.0)
+
+    # Well past STALL_TIMEOUT, but inside the declared budget.
+    assert orchestrator._find_stalled_tasks(["book"], 1390.0) == []
+
+
+def test_activity_grace_expires_and_task_is_flagged(monkeypatch):
+    """A genuinely wedged operation still dies - the grace never extends itself."""
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+    monkeypatch.setattr(orchestrator.time, "time", lambda: 1000.0)
+    orchestrator._last_activity["book"] = 1000.0
+    orchestrator.set_activity_grace("book", 400.0)
+
+    assert orchestrator._find_stalled_tasks(["book"], 1401.0) == ["book"]
+
+
+def test_set_activity_grace_is_clamped(monkeypatch):
+    """A caller cannot buy immortality by asking for an absurd grace."""
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+    monkeypatch.setattr(orchestrator.time, "time", lambda: 1000.0)
+    orchestrator.set_activity_grace("book", 10_000_000.0)
+
+    assert (
+        orchestrator._activity_grace["book"]
+        == 1000.0 + orchestrator._MAX_ACTIVITY_GRACE_SECONDS
+    )
+
+
+def test_max_activity_grace_covers_the_largest_bypass_budget():
+    """The clamp must not silently bite the one caller that exists."""
+    import shelfmark.download.http as http
+    import shelfmark.download.orchestrator as orchestrator
+    from shelfmark.bypass import external_bypasser, internal_bypasser
+
+    largest = (
+        max(
+            external_bypasser.max_duration_seconds(),
+            internal_bypasser.max_duration_seconds(),
+        )
+        + http._BYPASS_GRACE_SLACK_SECONDS
+    )
+
+    assert largest <= orchestrator._MAX_ACTIVITY_GRACE_SECONDS
+
+
+def test_set_activity_grace_touches_neither_queue_nor_websocket(monkeypatch):
+    """A liveness hint is not a user-visible status transition."""
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+    mock_queue = MagicMock()
+    mock_ws = MagicMock()
+    monkeypatch.setattr(orchestrator, "book_queue", mock_queue)
+    monkeypatch.setattr(orchestrator, "ws_manager", mock_ws)
+
+    orchestrator.set_activity_grace("book", 100.0)
+    orchestrator.clear_activity_grace("book")
+
+    assert mock_queue.mock_calls == []
+    assert mock_ws.mock_calls == []
+
+
+def test_clear_activity_grace_refreshes_last_activity(monkeypatch):
+    """Releasing a grace restarts the normal window rather than stalling instantly."""
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+    orchestrator._last_activity["book"] = 1.0
+    monkeypatch.setattr(orchestrator.time, "time", lambda: 5000.0)
+
+    orchestrator.set_activity_grace("book", 100.0)
+    orchestrator.clear_activity_grace("book")
+
+    assert "book" not in orchestrator._activity_grace
+    assert orchestrator._last_activity["book"] == 5000.0
+    assert orchestrator._find_stalled_tasks(["book"], 5000.0) == []
+
+
+def test_cleanup_progress_tracking_drops_activity_grace(monkeypatch):
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+    monkeypatch.setattr(orchestrator, "ws_manager", None)
+    orchestrator.set_activity_grace("book", 100.0)
+
+    orchestrator._cleanup_progress_tracking("book")
+
+    assert "book" not in orchestrator._activity_grace
+
+
+def test_update_download_status_rejects_the_grace_sentinel(monkeypatch):
+    """Defence in depth: the sentinel is intercepted upstream, but must be inert here too."""
+    import shelfmark.download.orchestrator as orchestrator
+    from shelfmark.download.activity import ACTIVITY_GRACE_STATUS
+
+    _reset(orchestrator)
+    mock_queue = MagicMock()
+    mock_ws = MagicMock()
+    monkeypatch.setattr(orchestrator, "book_queue", mock_queue)
+    monkeypatch.setattr(orchestrator, "ws_manager", mock_ws)
+    monkeypatch.setattr(orchestrator, "queue_status", lambda: {})
+
+    orchestrator.update_download_status("book", ACTIVITY_GRACE_STATUS, "330.0")
+
+    assert mock_queue.mock_calls == []
+    assert mock_ws.mock_calls == []
+    assert "book" not in orchestrator._last_activity
+
+
+def test_issue_1001_slow_bypass_is_not_cancelled_at_stall_timeout(monkeypatch):
+    """End-to-end replay of the issue #1001 timeline.
+
+    From a reporter's debug log: a 403 switched to the external bypasser at 07:04:33, five
+    FlareSolverr attempts each took ~64s and returned HTTP 500, and the watchdog cancelled
+    the download at 07:09:33.987 - exactly STALL_TIMEOUT later and 41s before the bypasser
+    would have finished and reported the real error.
+
+    Now the bypass declares its own budget, so the watchdog holds off and the user sees the
+    actual failure instead of a five-minute silent hang.
+    """
+    import shelfmark.download.http as http
+    import shelfmark.download.orchestrator as orchestrator
+    from shelfmark.bypass import external_bypasser
+    from shelfmark.download.activity import parse_activity_grace
+
+    _reset(orchestrator)
+    clock = [1000.0]
+    monkeypatch.setattr(orchestrator.time, "time", lambda: clock[0])
+
+    # Mirror the orchestrator's per-task status_callback closure.
+    events: list[tuple[str, str | None]] = []
+
+    def status_callback(status: str, message: str | None = None) -> None:
+        grace = parse_activity_grace(status, message)
+        if grace is not None:
+            if grace > 0:
+                orchestrator.set_activity_grace("book", grace)
+            else:
+                orchestrator.clear_activity_grace("book")
+            return
+        events.append((status, message))
+        orchestrator._last_activity["book"] = clock[0]
+
+    # The reporter was on external FlareSolverr with the default 60s timeout.
+    monkeypatch.setattr(http, "_is_cf_bypass_enabled", lambda: True)
+    monkeypatch.setattr(http, "_is_using_external_bypasser", lambda: True)
+    monkeypatch.setattr(http, "_get_external_bypasser", lambda: external_bypasser)
+    _stub_ext_bypasser_timeout(monkeypatch, external_bypasser, 60000)
+
+    stall_checks: list[list[str]] = []
+
+    def slow_failing_bypasser(*_args, **_kwargs):
+        # Five attempts at ~64s, then give up - as in the log.
+        for _attempt in range(5):
+            clock[0] += 64.0
+            stall_checks.append(orchestrator._find_stalled_tasks(["book"], clock[0]))
+        raise requests.exceptions.RequestException("500 Server Error")
+
+    monkeypatch.setattr(http, "get_bypassed_page", slow_failing_bypasser)
+
+    html = http.html_get_page(
+        "https://annas-archive.gl/slow_download/abc/0/6",
+        retry=1,
+        use_bypasser=True,
+        status_callback=status_callback,
+    )
+
+    # The bypass ran 320s - past STALL_TIMEOUT - and was never flagged as stalled.
+    assert 320.0 > orchestrator.STALL_TIMEOUT
+    assert stall_checks[-1] == []
+    assert all(check == [] for check in stall_checks)
+
+    # And the real reason reached the user instead of a generic stall message.
+    assert html == ""
+    assert [status for status, _m in events if status == "error"]
+    assert "500 Server Error" in str(events[-1][1])
+
+
+def test_issue_1001_bypass_overrunning_its_own_budget_is_still_cancelled(monkeypatch):
+    """The other half: declaring a budget must not make a wedged bypass immortal."""
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+    monkeypatch.setattr(orchestrator.time, "time", lambda: 1000.0)
+    orchestrator._last_activity["book"] = 1000.0
+
+    # External bypasser default budget (394s) plus http's 30s slack.
+    orchestrator.set_activity_grace("book", 424.0)
+
+    assert orchestrator._find_stalled_tasks(["book"], 1000.0 + 424.0) == []
+    assert orchestrator._find_stalled_tasks(["book"], 1000.0 + 425.0) == ["book"]
+
+
+def test_cancel_stalled_task_does_not_hold_the_progress_lock(monkeypatch):
+    """Regression guard: cancelling reaches a sqlite write that must not block the hub.
+
+    `book_queue.cancel_download` runs the terminal-status hooks, which are not
+    gevent-patched. Holding `_progress_lock` across that stalls every download worker.
+    """
+    import shelfmark.download.orchestrator as orchestrator
+
+    _reset(orchestrator)
+    observed: list[bool] = []
+
+    def fake_cancel(_task_id: str) -> bool:
+        acquired = orchestrator._progress_lock.acquire(blocking=False)
+        observed.append(acquired)
+        if acquired:
+            orchestrator._progress_lock.release()
+        return True
+
+    mock_queue = MagicMock()
+    mock_queue.cancel_download.side_effect = fake_cancel
+    monkeypatch.setattr(orchestrator, "book_queue", mock_queue)
+
+    orchestrator._cancel_stalled_task("book")
+
+    assert observed == [True], "_progress_lock was held while cancelling a stalled task"
+    mock_queue.update_status_message.assert_called_once_with(
+        "book", f"Download stalled (no activity for {orchestrator.STALL_TIMEOUT}s)"
+    )

--- a/tests/download/test_orchestrator_stall.py
+++ b/tests/download/test_orchestrator_stall.py
@@ -93,10 +93,7 @@ def test_set_activity_grace_is_clamped(monkeypatch):
     monkeypatch.setattr(orchestrator.time, "time", lambda: 1000.0)
     orchestrator.set_activity_grace("book", 10_000_000.0)
 
-    assert (
-        orchestrator._activity_grace["book"]
-        == 1000.0 + orchestrator._MAX_ACTIVITY_GRACE_SECONDS
-    )
+    assert orchestrator._activity_grace["book"] == 1000.0 + orchestrator._MAX_ACTIVITY_GRACE_SECONDS
 
 
 def test_max_activity_grace_covers_the_largest_bypass_budget():


### PR DESCRIPTION
A download that hits Cloudflare hung on "Bypassing protection..." for five
minutes and then died, regardless of which bypasser was configured.

html_get_page() started a BypassHeartbeat thread to keep the download marked
alive during a bypass, but the thread had no loop: it fired one status event
and returned. Even with the loop restored it could not have worked, because
update_download_status() dedupes identical (status, message) tuples and
returns before refreshing _last_activity, and the heartbeat re-sent the
byte-identical payload already emitted just above it.

So _last_activity was frozen for the whole bypass, while both bypassers are
allowed to run longer than STALL_TIMEOUT (external FlareSolverr ~394s at
default settings, internal 420s per get() call). The watchdog always won.
From a reporter's log: 403 at 07:04:33.390, cancelled at 07:09:33.987 -
exactly 300.000s, and 41s before the bypasser would have finished and
reported the real error, an HTTP 500 from FlareSolverr the user never saw.

The regression is not one commit. 1f093de (#536) added the heartbeat and the
dedup together and refreshed activity before the dedup return, so it worked.
ff094be (#832) moved the refresh below that return while tightening stall
detection for #823. 3a3a3ce (#845) then deleted the heartbeat's while loop
to silence a B023 lint, removing the last evidence of intent.

The dedup itself is correct and stays: a keep-alive that ticks on a timer
proves nothing about whether an operation is progressing, so letting it
refresh the stall clock would make a wedged download immortal. Split the two
concerns instead.

Add shelfmark/download/activity.py. A long single-shot operation declares its
own upper bound once, over a sentinel status carried on the existing
status_callback channel - so no new parameter has to be threaded through every
handler, post-processor and output module. The orchestrator intercepts the
sentinel in its per-task closure and records an absolute deadline in
_activity_grace, which stall detection honours alongside STALL_TIMEOUT. The
grace never extends itself and is clamped to _MAX_ACTIVITY_GRACE_SECONDS, so
an operation that overruns its own declared budget is still cancelled.

Each bypasser now reports max_duration_seconds() derived from its own retry
and timeout settings, and http.py asks whichever is active, plus 30s of slack
so the bypasser's own deadline expires first and the user sees its real
failure. On that path html_get_page() also emits status_callback("error", ...)
rather than silently returning an empty page.

Three further fixes on the same code path:

- Extract the watchdog into _find_stalled_tasks() and _cancel_stalled_task().
  It was the only place holding _progress_lock across a call into book_queue,
  whose terminal-status hooks reach a sqlite write that gevent does not patch,
  blocking the hub and every download worker. It now holds the lock for dict
  reads only.
- Bound _CDP_WORKER.run(), which waited with timeout=None while holding the
  module-wide LOCKED, so a single wedged in-process CDP session blocked every
  subsequent bypass forever on non-Docker installs.
- Broaden the coordinator loop's except clause back to Exception, with
  escalating backoff. 8d98e12 (#868) narrowed it to a six-type tuple to
  silence BLE001, which let gevent's LoopExit and similar kill the only thread
  driving the download queue - undoing #832's fix for #823 and resurfacing it
  as #1166. GreenletExit and gevent.Timeout still propagate.

Fixes #1001
Refs #1166, #823
