### PR TITLE
feat(prowlarr): warn when an indexer declares a format Shelfmark can't process

### DIFF
--- a/shelfmark/release_sources/prowlarr/source.py
+++ b/shelfmark/release_sources/prowlarr/source.py
@@ -317,19 +317,25 @@ def _extract_mam_language(raw_title: str) -> str | None:
     return None
 
 
-def _extract_mam_formats(raw_title: str) -> list[str]:
-    """Extract a list of formats from MyAnonamouse titles.
+def _split_mam_formats(raw_title: str) -> tuple[list[str], list[str]]:
+    """Split the format tokens of a MyAnonamouse title into (recognized, unrecognized).
 
     Prowlarr's MAM parser appends a structured bracket segment like:
       [ENG / EPUB MOBI PDF]
 
     We only trust this structured segment (and do not attempt generic title
     heuristics for other indexers).
+
+    Tokens after the "/" that Shelfmark does not know as a book or audiobook format
+    (e.g. ``[ENG / MP4]``) are returned separately so the UI can warn that the release
+    will download but cannot be processed, instead of showing a bare content-type icon
+    that looks like an ordinary result.
     """
     if not raw_title:
-        return []
+        return [], []
 
     format_set = set(ALL_BOOK_FORMATS)
+    first_unrecognized: list[str] | None = None
     for bracket in re.findall(r"\[([^\]]+)\]", raw_title):
         if "/" not in bracket:
             continue
@@ -338,15 +344,26 @@ def _extract_mam_formats(raw_title: str) -> list[str]:
         tokens = re.findall(r"[A-Za-z0-9]+", after_slash)
 
         formats: list[str] = []
+        unrecognized: list[str] = []
         for token in tokens:
             fmt = token.lower()
-            if fmt in format_set and fmt not in formats:
-                formats.append(fmt)
+            if fmt in format_set:
+                if fmt not in formats:
+                    formats.append(fmt)
+            elif fmt not in unrecognized:
+                unrecognized.append(fmt)
 
         if formats:
-            return formats
+            return formats, unrecognized
+        if unrecognized and first_unrecognized is None:
+            first_unrecognized = unrecognized
 
-    return []
+    return [], first_unrecognized or []
+
+
+def _extract_mam_formats(raw_title: str) -> list[str]:
+    """Extract the recognized formats from a MyAnonamouse title (see _split_mam_formats)."""
+    return _split_mam_formats(raw_title)[0]
 
 
 def _formats_display(formats: list[str]) -> str | None:
@@ -485,6 +502,7 @@ def _prowlarr_result_to_release(
 
     format_detected: str | None = None
     formats: list[str] = []
+    unrecognized_formats: list[str] = []
     formats_display: str | None = None
     language_detected: str | None = None
     if enable_format_detection:
@@ -492,7 +510,7 @@ def _prowlarr_result_to_release(
         if book_title:
             title = book_title
 
-        formats = _extract_mam_formats(str(raw_title or ""))
+        formats, unrecognized_formats = _split_mam_formats(str(raw_title or ""))
         format_detected = formats[0] if formats else None
         formats_display = _formats_display(formats)
         language_detected = _extract_mam_language(str(raw_title or ""))
@@ -554,6 +572,9 @@ def _prowlarr_result_to_release(
             "info_hash": result.get("infoHash"),
             "formats": formats or None,
             "formats_display": formats_display,
+            # Format tokens the indexer declared but Shelfmark can't process (#1264-style
+            # "[ENG / MP4]"). Lets the UI warn instead of showing a bare content icon.
+            "unrecognized_formats": unrecognized_formats or None,
             # Raw torznab attributes for rich tooltips (enriched indexers)
             "torznab_attrs": result.get("torznabAttrs"),
         },

--- a/src/frontend/src/components/ReleaseCell.tsx
+++ b/src/frontend/src/components/ReleaseCell.tsx
@@ -1,5 +1,9 @@
-import type { ColumnSchema, Release } from '../types';
-import { getColorStyleFromHint, getProtocolDotColor, getFormatColor } from '../utils/colorMaps';
+import type { ColumnSchema, Release } from "../types";
+import {
+  getColorStyleFromHint,
+  getProtocolDotColor,
+  getFormatColor,
+} from "../utils/colorMaps";
 import {
   getNestedValue,
   isRecord,
@@ -7,8 +11,9 @@ import {
   toNumberValue,
   toStringArray,
   toStringValue,
-} from '../utils/objectHelpers';
-import { Tooltip } from './shared/Tooltip';
+} from "../utils/objectHelpers";
+import { Tooltip } from "./shared/Tooltip";
+import { getUnrecognizedReleaseFormats } from "../utils/releaseFormats";
 
 interface ReleaseCellProps {
   column: ColumnSchema;
@@ -22,19 +27,19 @@ const normalizeFlagLabel = (tag: string): string => {
   if (!normalized) return tag;
 
   switch (normalized) {
-    case 'freeleech':
-    case 'free leech':
-    case 'fl':
-      return 'FL';
-    case 'double upload':
-    case 'doubleupload':
-    case 'du':
-      return 'DU';
-    case 'vip':
-      return 'VIP';
-    case 'internal':
-    case 'int':
-      return 'INT';
+    case "freeleech":
+    case "free leech":
+    case "fl":
+      return "FL";
+    case "double upload":
+    case "doubleupload":
+    case "du":
+      return "DU";
+    case "vip":
+      return "VIP";
+    case "internal":
+    case "int":
+      return "INT";
     default:
       return tag;
   }
@@ -49,8 +54,8 @@ const formatRelativeTime = (dateString: string): string | null => {
     const diffMs = now.getTime() - date.getTime();
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
-    if (diffDays === 0) return 'Today';
-    if (diffDays === 1) return '1 day';
+    if (diffDays === 0) return "Today";
+    if (diffDays === 1) return "1 day";
 
     return `${diffDays} days`;
   } catch {
@@ -58,7 +63,10 @@ const formatRelativeTime = (dateString: string): string | null => {
   }
 };
 
-const getDuplicateAwareKey = (counts: Map<string, number>, keyBase: string): string => {
+const getDuplicateAwareKey = (
+  counts: Map<string, number>,
+  keyBase: string,
+): string => {
   const nextCount = (counts.get(keyBase) ?? 0) + 1;
   counts.set(keyBase, nextCount);
 
@@ -78,20 +86,22 @@ export const ReleaseCell = ({
 }: ReleaseCellProps) => {
   const rawValue = getNestedValue(release, column.key);
   const cellValue =
-    rawValue !== undefined && rawValue !== null ? toComparableText(rawValue) : column.fallback;
+    rawValue !== undefined && rawValue !== null
+      ? toComparableText(rawValue)
+      : column.fallback;
 
   const displayValue = column.uppercase ? cellValue.toUpperCase() : cellValue;
 
   // Alignment classes
   const alignClass = {
-    left: 'text-left justify-start',
-    center: 'text-center justify-center',
-    right: 'text-right justify-end',
+    left: "text-left justify-start",
+    center: "text-center justify-center",
+    right: "text-right justify-end",
   }[column.align];
 
   // Render based on type
   switch (column.render_type) {
-    case 'badge': {
+    case "badge": {
       // Compact mode: render as plain text (for mobile info lines)
       if (compact) {
         return <span>{displayValue}</span>;
@@ -100,7 +110,7 @@ export const ReleaseCell = ({
 
       // Build rich tooltip content for formats
       let tooltipContent: React.ReactNode = null;
-      if (column.key === 'extra.formats_display') {
+      if (column.key === "extra.formats_display") {
         const formats = release.extra?.formats;
         if (Array.isArray(formats) && formats.length > 1) {
           tooltipContent = (
@@ -148,17 +158,21 @@ export const ReleaseCell = ({
       );
     }
 
-    case 'tags': {
+    case "tags": {
       let tags: string[] = [];
       if (Array.isArray(rawValue)) {
-        tags = rawValue.map((tag) => toComparableText(tag)).filter((tag) => tag.trim());
+        tags = rawValue
+          .map((tag) => toComparableText(tag))
+          .filter((tag) => tag.trim());
       } else if (rawValue !== undefined && rawValue !== null) {
         const comparableValue = toComparableText(rawValue).trim();
         if (comparableValue) {
           tags = [comparableValue];
         }
       }
-      const isFlags = column.color_hint?.type === 'map' && column.color_hint.value === 'flags';
+      const isFlags =
+        column.color_hint?.type === "map" &&
+        column.color_hint.value === "flags";
 
       if (compact) {
         if (tags.length === 0) {
@@ -168,7 +182,7 @@ export const ReleaseCell = ({
           const normalized = isFlags ? normalizeFlagLabel(tag) : tag;
           return column.uppercase ? normalized.toUpperCase() : normalized;
         });
-        return <span>{displayTags.join(', ')}</span>;
+        return <span>{displayTags.join(", ")}</span>;
       }
 
       if (!tags.length) {
@@ -190,9 +204,14 @@ export const ReleaseCell = ({
         <div className={`flex flex-wrap items-center gap-1.5 ${alignClass}`}>
           {tags.map((tag) => {
             const normalized = isFlags ? normalizeFlagLabel(tag) : tag;
-            const displayTag = column.uppercase ? normalized.toUpperCase() : normalized;
+            const displayTag = column.uppercase
+              ? normalized.toUpperCase()
+              : normalized;
             const colorStyle = getColorStyleFromHint(tag, column.color_hint);
-            const tagKey = getDuplicateAwareKey(tagKeyCounts, `${column.key}|${displayTag}`);
+            const tagKey = getDuplicateAwareKey(
+              tagKeyCounts,
+              `${column.key}|${displayTag}`,
+            );
 
             return (
               <span
@@ -207,10 +226,12 @@ export const ReleaseCell = ({
       );
     }
 
-    case 'size': {
+    case "size": {
       // Build tooltip from extra metadata (torznab attrs, publish date, etc.)
       const extra = release.extra;
-      const torznabAttrs = isRecord(extra?.torznab_attrs) ? extra.torznab_attrs : undefined;
+      const torznabAttrs = isRecord(extra?.torznab_attrs)
+        ? extra.torznab_attrs
+        : undefined;
       const publishDate = toStringValue(extra?.publish_date);
       const postedDate = toStringValue(extra?.posted_date);
       const bitrate = toStringValue(extra?.bitrate);
@@ -221,36 +242,36 @@ export const ReleaseCell = ({
       if (publishDate) {
         const relativeTime = formatRelativeTime(publishDate);
         if (relativeTime) {
-          rows.push({ label: 'Added', value: relativeTime });
+          rows.push({ label: "Added", value: relativeTime });
         }
       }
 
       if (postedDate) {
         const postedDateValue = postedDate.trim();
         const relativeTime = formatRelativeTime(postedDateValue);
-        rows.push({ label: 'Posted', value: relativeTime ?? postedDateValue });
+        rows.push({ label: "Posted", value: relativeTime ?? postedDateValue });
       }
 
       if (bitrate) {
         const bitrateValue = bitrate.trim();
         if (bitrateValue) {
-          rows.push({ label: 'Bitrate', value: bitrateValue });
+          rows.push({ label: "Bitrate", value: bitrateValue });
         }
       }
 
       // Add torznab attributes if available (MAM, etc.)
       if (torznabAttrs && Object.keys(torznabAttrs).length > 0) {
         const displayAttrs: Array<{ key: string; label: string }> = [
-          { key: 'description', label: 'Description' },
-          { key: 'year', label: 'Year' },
-          { key: 'genre', label: 'Genre' },
-          { key: 'narrator', label: 'Narrator' },
-          { key: 'bitrate', label: 'Bitrate' },
-          { key: 'samplerate', label: 'Sample Rate' },
-          { key: 'runtime', label: 'Runtime' },
-          { key: 'pages', label: 'Pages' },
-          { key: 'publisher', label: 'Publisher' },
-          { key: 'language', label: 'Language' },
+          { key: "description", label: "Description" },
+          { key: "year", label: "Year" },
+          { key: "genre", label: "Genre" },
+          { key: "narrator", label: "Narrator" },
+          { key: "bitrate", label: "Bitrate" },
+          { key: "samplerate", label: "Sample Rate" },
+          { key: "runtime", label: "Runtime" },
+          { key: "pages", label: "Pages" },
+          { key: "publisher", label: "Publisher" },
+          { key: "language", label: "Language" },
         ];
 
         for (const attr of displayAttrs) {
@@ -265,10 +286,10 @@ export const ReleaseCell = ({
       const files = toNumberValue(extra?.files);
       const grabs = toNumberValue(extra?.grabs);
       if (files !== undefined && files !== null) {
-        rows.push({ label: 'Files', value: String(files) });
+        rows.push({ label: "Files", value: String(files) });
       }
       if (grabs !== undefined && grabs !== null) {
-        rows.push({ label: 'Grabs', value: String(grabs) });
+        rows.push({ label: "Grabs", value: String(grabs) });
       }
 
       let sizeTooltipContent: React.ReactNode = null;
@@ -277,7 +298,9 @@ export const ReleaseCell = ({
           <div className="flex max-w-xs flex-col gap-1">
             {rows.map((row) => (
               <div key={row.label} className="flex gap-2">
-                <span className="shrink-0 text-gray-400 dark:text-gray-500">{row.label}:</span>
+                <span className="shrink-0 text-gray-400 dark:text-gray-500">
+                  {row.label}:
+                </span>
                 <span className="truncate">{row.value}</span>
               </div>
             ))}
@@ -292,7 +315,9 @@ export const ReleaseCell = ({
       const sizeText = <span>{displayValue}</span>;
 
       return (
-        <div className={`flex items-center ${alignClass} text-xs text-gray-600 dark:text-gray-300`}>
+        <div
+          className={`flex items-center ${alignClass} text-xs text-gray-600 dark:text-gray-300`}
+        >
           {sizeTooltipContent ? (
             <Tooltip content={sizeTooltipContent} position="left">
               {sizeText}
@@ -304,7 +329,7 @@ export const ReleaseCell = ({
       );
     }
 
-    case 'peers': {
+    case "peers": {
       // Peers display: "S/L" string with badge colored by seeder count
       // Color logic: 0 = red, 1-10 = yellow, 10+ = blue
       const seeders = release.seeders;
@@ -328,16 +353,18 @@ export const ReleaseCell = ({
       // Determine color based on seeder count
       let badgeColors: string;
       if (seeders >= 10) {
-        badgeColors = 'bg-blue-500/20 text-blue-700 dark:text-blue-300';
+        badgeColors = "bg-blue-500/20 text-blue-700 dark:text-blue-300";
       } else if (seeders >= 1) {
-        badgeColors = 'bg-yellow-500/20 text-yellow-700 dark:text-yellow-300';
+        badgeColors = "bg-yellow-500/20 text-yellow-700 dark:text-yellow-300";
       } else {
-        badgeColors = 'bg-red-500/20 text-red-700 dark:text-red-300';
+        badgeColors = "bg-red-500/20 text-red-700 dark:text-red-300";
       }
 
       if (compact) {
         return (
-          <span className={`font-medium ${badgeColors.split(' ').slice(1).join(' ')}`}>
+          <span
+            className={`font-medium ${badgeColors.split(" ").slice(1).join(" ")}`}
+          >
             {peersValue}
           </span>
         );
@@ -353,15 +380,15 @@ export const ReleaseCell = ({
       );
     }
 
-    case 'indexer_protocol': {
+    case "indexer_protocol": {
       // Indexer name with colored dot indicating protocol (torrent/usenet) and peers count
       const protocol = release.protocol as string | undefined;
       const dotColor = getProtocolDotColor(protocol);
-      let protocolLabel = protocol || 'Unknown';
-      if (protocol === 'torrent') {
-        protocolLabel = 'Torrent';
-      } else if (protocol === 'nzb') {
-        protocolLabel = 'Usenet';
+      let protocolLabel = protocol || "Unknown";
+      if (protocol === "torrent") {
+        protocolLabel = "Torrent";
+      } else if (protocol === "nzb") {
+        protocolLabel = "Usenet";
       }
       const peers = release.peers;
 
@@ -381,28 +408,40 @@ export const ReleaseCell = ({
         <div
           className={`flex items-center ${alignClass} gap-1.5 truncate text-xs text-gray-600 dark:text-gray-300`}
         >
-          <span className={`h-2 w-2 shrink-0 rounded-full ${dotColor}`} title={protocolLabel} />
+          <span
+            className={`h-2 w-2 shrink-0 rounded-full ${dotColor}`}
+            title={protocolLabel}
+          />
           {/* Titled because one tracker can appear as several indexer entries whose
               names share a prefix, and truncation would make the rows look identical */}
           <span className="truncate" title={displayValue}>
             {displayValue}
           </span>
-          {peers && <span className="shrink-0 text-gray-400 dark:text-gray-500">{peers}</span>}
+          {peers && (
+            <span className="shrink-0 text-gray-400 dark:text-gray-500">
+              {peers}
+            </span>
+          )}
         </div>
       );
     }
 
-    case 'flag_icon': {
+    case "flag_icon": {
       // Colored badge showing FL, VIP, or both
       if (!cellValue || cellValue === column.fallback) {
         if (compact) return null;
         return <div className={`flex items-center ${alignClass}`} />;
       }
 
-      const flagColor = getColorStyleFromHint(cellValue, { type: 'map', value: 'flags' });
+      const flagColor = getColorStyleFromHint(cellValue, {
+        type: "map",
+        value: "flags",
+      });
 
       if (compact) {
-        return <span className={`${flagColor.text} font-medium`}>{cellValue}</span>;
+        return (
+          <span className={`${flagColor.text} font-medium`}>{cellValue}</span>
+        );
       }
       return (
         <div className={`flex items-center ${alignClass}`}>
@@ -415,20 +454,65 @@ export const ReleaseCell = ({
       );
     }
 
-    case 'format_content_type': {
+    case "format_content_type": {
       // Content type icon + format badge combined
       // Shows primary format as badge with colored dots for additional formats
       const contentType = release.content_type;
-      const isAudiobook = contentType === 'audiobook';
+      const isAudiobook = contentType === "audiobook";
       const formats = toStringArray(release.extra?.formats);
       const primaryFormat = formats?.[0] || null;
       const additionalFormats = formats?.slice(1) || [];
 
+      // The indexer named a format Shelfmark can't process (e.g. MAM "[ENG / MP4]").
+      // Downloading it would only fail post-processing, so warn instead of showing the
+      // bare content-type icon that makes it look like any other result.
+      const unrecognizedFormats = primaryFormat
+        ? []
+        : getUnrecognizedReleaseFormats(release);
+      if (unrecognizedFormats.length > 0) {
+        const unsupportedLabel = unrecognizedFormats
+          .map((fmt) => fmt.toUpperCase())
+          .join(", ");
+        const unsupportedTitle = `Unsupported format (${unsupportedLabel}) - Shelfmark cannot process this release`;
+        if (compact) {
+          return (
+            <span
+              className="font-semibold text-amber-600 dark:text-amber-400"
+              title={unsupportedTitle}
+            >
+              {unrecognizedFormats[0].toUpperCase()}
+              {unrecognizedFormats.length > 1 &&
+                ` +${unrecognizedFormats.length - 1}`}
+            </span>
+          );
+        }
+        return (
+          <div
+            className="flex items-center justify-start"
+            title={unsupportedTitle}
+          >
+            <span className="inline-flex items-center gap-1">
+              <span className="w-13 rounded-lg bg-amber-500/20 py-0.5 text-center text-[10px] font-semibold tracking-wide whitespace-nowrap text-amber-700 sm:text-[11px] dark:text-amber-400">
+                {unrecognizedFormats[0].toUpperCase()}
+              </span>
+              <span className="text-[10px] font-medium whitespace-nowrap text-amber-700 sm:text-[11px] dark:text-amber-400">
+                Unsupported
+              </span>
+            </span>
+          </div>
+        );
+      }
+
       // Use blue for book, violet for audiobook when no format specified
       const noFormatStyle = isAudiobook
-        ? { bg: 'bg-violet-500/20', text: 'text-violet-600 dark:text-violet-400' }
-        : { bg: 'bg-blue-500/20', text: 'text-blue-600 dark:text-blue-400' };
-      const colorStyle = primaryFormat ? getFormatColor(primaryFormat) : noFormatStyle;
+        ? {
+            bg: "bg-violet-500/20",
+            text: "text-violet-600 dark:text-violet-400",
+          }
+        : { bg: "bg-blue-500/20", text: "text-blue-600 dark:text-blue-400" };
+      const colorStyle = primaryFormat
+        ? getFormatColor(primaryFormat)
+        : noFormatStyle;
 
       // Build rich tooltip content for formats (if multiple)
       let tooltipContent: React.ReactNode = null;
@@ -488,7 +572,7 @@ export const ReleaseCell = ({
           return (
             <span
               className="inline-flex items-center text-gray-500"
-              title={isAudiobook ? 'Audiobook' : 'Book'}
+              title={isAudiobook ? "Audiobook" : "Book"}
             >
               {icon}
             </span>
@@ -497,10 +581,13 @@ export const ReleaseCell = ({
         // Simple text tooltip for compact mode
         const compactTooltip =
           formats && formats.length > 1
-            ? formats.map((fmt) => fmt.toUpperCase()).join(', ')
+            ? formats.map((fmt) => fmt.toUpperCase()).join(", ")
             : undefined;
         return (
-          <span className={column.uppercase ? 'uppercase' : ''} title={compactTooltip}>
+          <span
+            className={column.uppercase ? "uppercase" : ""}
+            title={compactTooltip}
+          >
             {primaryFormat.toUpperCase()}
             {additionalFormats.length > 0 && ` +${additionalFormats.length}`}
           </span>
@@ -512,7 +599,7 @@ export const ReleaseCell = ({
         return (
           <div
             className="flex items-center justify-start"
-            title={isAudiobook ? 'Audiobook' : 'Book'}
+            title={isAudiobook ? "Audiobook" : "Book"}
           >
             <span
               className={`${colorStyle.bg} ${colorStyle.text} inline-flex w-13 items-center justify-center rounded-lg py-0.5 text-[10px] font-semibold sm:text-[11px]`}
@@ -552,20 +639,23 @@ export const ReleaseCell = ({
       );
     }
 
-    case 'number':
+    case "number":
       if (compact) {
         return <span>{displayValue}</span>;
       }
       return (
-        <div className={`flex items-center ${alignClass} text-xs text-gray-600 dark:text-gray-300`}>
+        <div
+          className={`flex items-center ${alignClass} text-xs text-gray-600 dark:text-gray-300`}
+        >
           {displayValue}
         </div>
       );
 
-    case 'text':
+    case "text":
     default: {
       // Check if this is a server column with online status data
-      const isServerColumn = column.key === 'extra.server' && onlineServers !== undefined;
+      const isServerColumn =
+        column.key === "extra.server" && onlineServers !== undefined;
       const isOnline = isServerColumn && onlineServers?.includes(cellValue);
 
       if (compact) {
@@ -573,8 +663,8 @@ export const ReleaseCell = ({
           return (
             <span className="inline-flex items-center gap-1">
               <span
-                className={`h-1.5 w-1.5 shrink-0 rounded-full ${isOnline ? 'bg-emerald-500' : 'bg-gray-400'}`}
-                title={isOnline ? 'Online' : 'Offline'}
+                className={`h-1.5 w-1.5 shrink-0 rounded-full ${isOnline ? "bg-emerald-500" : "bg-gray-400"}`}
+                title={isOnline ? "Online" : "Offline"}
               />
               {displayValue}
             </span>
@@ -589,8 +679,8 @@ export const ReleaseCell = ({
         >
           {isServerColumn && (
             <span
-              className={`mr-1.5 h-2 w-2 shrink-0 rounded-full ${isOnline ? 'bg-emerald-500' : 'bg-gray-400'}`}
-              title={isOnline ? 'Online' : 'Offline'}
+              className={`mr-1.5 h-2 w-2 shrink-0 rounded-full ${isOnline ? "bg-emerald-500" : "bg-gray-400"}`}
+              title={isOnline ? "Online" : "Offline"}
             />
           )}
           {displayValue}

--- a/src/frontend/src/components/ReleaseCell.tsx
+++ b/src/frontend/src/components/ReleaseCell.tsx
@@ -1,9 +1,5 @@
-import type { ColumnSchema, Release } from "../types";
-import {
-  getColorStyleFromHint,
-  getProtocolDotColor,
-  getFormatColor,
-} from "../utils/colorMaps";
+import type { ColumnSchema, Release } from '../types';
+import { getColorStyleFromHint, getProtocolDotColor, getFormatColor } from '../utils/colorMaps';
 import {
   getNestedValue,
   isRecord,
@@ -11,9 +7,9 @@ import {
   toNumberValue,
   toStringArray,
   toStringValue,
-} from "../utils/objectHelpers";
-import { Tooltip } from "./shared/Tooltip";
-import { getUnrecognizedReleaseFormats } from "../utils/releaseFormats";
+} from '../utils/objectHelpers';
+import { getUnrecognizedReleaseFormats } from '../utils/releaseFormats';
+import { Tooltip } from './shared/Tooltip';
 
 interface ReleaseCellProps {
   column: ColumnSchema;
@@ -27,19 +23,19 @@ const normalizeFlagLabel = (tag: string): string => {
   if (!normalized) return tag;
 
   switch (normalized) {
-    case "freeleech":
-    case "free leech":
-    case "fl":
-      return "FL";
-    case "double upload":
-    case "doubleupload":
-    case "du":
-      return "DU";
-    case "vip":
-      return "VIP";
-    case "internal":
-    case "int":
-      return "INT";
+    case 'freeleech':
+    case 'free leech':
+    case 'fl':
+      return 'FL';
+    case 'double upload':
+    case 'doubleupload':
+    case 'du':
+      return 'DU';
+    case 'vip':
+      return 'VIP';
+    case 'internal':
+    case 'int':
+      return 'INT';
     default:
       return tag;
   }
@@ -54,8 +50,8 @@ const formatRelativeTime = (dateString: string): string | null => {
     const diffMs = now.getTime() - date.getTime();
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
-    if (diffDays === 0) return "Today";
-    if (diffDays === 1) return "1 day";
+    if (diffDays === 0) return 'Today';
+    if (diffDays === 1) return '1 day';
 
     return `${diffDays} days`;
   } catch {
@@ -63,10 +59,7 @@ const formatRelativeTime = (dateString: string): string | null => {
   }
 };
 
-const getDuplicateAwareKey = (
-  counts: Map<string, number>,
-  keyBase: string,
-): string => {
+const getDuplicateAwareKey = (counts: Map<string, number>, keyBase: string): string => {
   const nextCount = (counts.get(keyBase) ?? 0) + 1;
   counts.set(keyBase, nextCount);
 
@@ -86,22 +79,20 @@ export const ReleaseCell = ({
 }: ReleaseCellProps) => {
   const rawValue = getNestedValue(release, column.key);
   const cellValue =
-    rawValue !== undefined && rawValue !== null
-      ? toComparableText(rawValue)
-      : column.fallback;
+    rawValue !== undefined && rawValue !== null ? toComparableText(rawValue) : column.fallback;
 
   const displayValue = column.uppercase ? cellValue.toUpperCase() : cellValue;
 
   // Alignment classes
   const alignClass = {
-    left: "text-left justify-start",
-    center: "text-center justify-center",
-    right: "text-right justify-end",
+    left: 'text-left justify-start',
+    center: 'text-center justify-center',
+    right: 'text-right justify-end',
   }[column.align];
 
   // Render based on type
   switch (column.render_type) {
-    case "badge": {
+    case 'badge': {
       // Compact mode: render as plain text (for mobile info lines)
       if (compact) {
         return <span>{displayValue}</span>;
@@ -110,7 +101,7 @@ export const ReleaseCell = ({
 
       // Build rich tooltip content for formats
       let tooltipContent: React.ReactNode = null;
-      if (column.key === "extra.formats_display") {
+      if (column.key === 'extra.formats_display') {
         const formats = release.extra?.formats;
         if (Array.isArray(formats) && formats.length > 1) {
           tooltipContent = (
@@ -158,21 +149,17 @@ export const ReleaseCell = ({
       );
     }
 
-    case "tags": {
+    case 'tags': {
       let tags: string[] = [];
       if (Array.isArray(rawValue)) {
-        tags = rawValue
-          .map((tag) => toComparableText(tag))
-          .filter((tag) => tag.trim());
+        tags = rawValue.map((tag) => toComparableText(tag)).filter((tag) => tag.trim());
       } else if (rawValue !== undefined && rawValue !== null) {
         const comparableValue = toComparableText(rawValue).trim();
         if (comparableValue) {
           tags = [comparableValue];
         }
       }
-      const isFlags =
-        column.color_hint?.type === "map" &&
-        column.color_hint.value === "flags";
+      const isFlags = column.color_hint?.type === 'map' && column.color_hint.value === 'flags';
 
       if (compact) {
         if (tags.length === 0) {
@@ -182,7 +169,7 @@ export const ReleaseCell = ({
           const normalized = isFlags ? normalizeFlagLabel(tag) : tag;
           return column.uppercase ? normalized.toUpperCase() : normalized;
         });
-        return <span>{displayTags.join(", ")}</span>;
+        return <span>{displayTags.join(', ')}</span>;
       }
 
       if (!tags.length) {
@@ -204,14 +191,9 @@ export const ReleaseCell = ({
         <div className={`flex flex-wrap items-center gap-1.5 ${alignClass}`}>
           {tags.map((tag) => {
             const normalized = isFlags ? normalizeFlagLabel(tag) : tag;
-            const displayTag = column.uppercase
-              ? normalized.toUpperCase()
-              : normalized;
+            const displayTag = column.uppercase ? normalized.toUpperCase() : normalized;
             const colorStyle = getColorStyleFromHint(tag, column.color_hint);
-            const tagKey = getDuplicateAwareKey(
-              tagKeyCounts,
-              `${column.key}|${displayTag}`,
-            );
+            const tagKey = getDuplicateAwareKey(tagKeyCounts, `${column.key}|${displayTag}`);
 
             return (
               <span
@@ -226,12 +208,10 @@ export const ReleaseCell = ({
       );
     }
 
-    case "size": {
+    case 'size': {
       // Build tooltip from extra metadata (torznab attrs, publish date, etc.)
       const extra = release.extra;
-      const torznabAttrs = isRecord(extra?.torznab_attrs)
-        ? extra.torznab_attrs
-        : undefined;
+      const torznabAttrs = isRecord(extra?.torznab_attrs) ? extra.torznab_attrs : undefined;
       const publishDate = toStringValue(extra?.publish_date);
       const postedDate = toStringValue(extra?.posted_date);
       const bitrate = toStringValue(extra?.bitrate);
@@ -242,36 +222,36 @@ export const ReleaseCell = ({
       if (publishDate) {
         const relativeTime = formatRelativeTime(publishDate);
         if (relativeTime) {
-          rows.push({ label: "Added", value: relativeTime });
+          rows.push({ label: 'Added', value: relativeTime });
         }
       }
 
       if (postedDate) {
         const postedDateValue = postedDate.trim();
         const relativeTime = formatRelativeTime(postedDateValue);
-        rows.push({ label: "Posted", value: relativeTime ?? postedDateValue });
+        rows.push({ label: 'Posted', value: relativeTime ?? postedDateValue });
       }
 
       if (bitrate) {
         const bitrateValue = bitrate.trim();
         if (bitrateValue) {
-          rows.push({ label: "Bitrate", value: bitrateValue });
+          rows.push({ label: 'Bitrate', value: bitrateValue });
         }
       }
 
       // Add torznab attributes if available (MAM, etc.)
       if (torznabAttrs && Object.keys(torznabAttrs).length > 0) {
         const displayAttrs: Array<{ key: string; label: string }> = [
-          { key: "description", label: "Description" },
-          { key: "year", label: "Year" },
-          { key: "genre", label: "Genre" },
-          { key: "narrator", label: "Narrator" },
-          { key: "bitrate", label: "Bitrate" },
-          { key: "samplerate", label: "Sample Rate" },
-          { key: "runtime", label: "Runtime" },
-          { key: "pages", label: "Pages" },
-          { key: "publisher", label: "Publisher" },
-          { key: "language", label: "Language" },
+          { key: 'description', label: 'Description' },
+          { key: 'year', label: 'Year' },
+          { key: 'genre', label: 'Genre' },
+          { key: 'narrator', label: 'Narrator' },
+          { key: 'bitrate', label: 'Bitrate' },
+          { key: 'samplerate', label: 'Sample Rate' },
+          { key: 'runtime', label: 'Runtime' },
+          { key: 'pages', label: 'Pages' },
+          { key: 'publisher', label: 'Publisher' },
+          { key: 'language', label: 'Language' },
         ];
 
         for (const attr of displayAttrs) {
@@ -286,10 +266,10 @@ export const ReleaseCell = ({
       const files = toNumberValue(extra?.files);
       const grabs = toNumberValue(extra?.grabs);
       if (files !== undefined && files !== null) {
-        rows.push({ label: "Files", value: String(files) });
+        rows.push({ label: 'Files', value: String(files) });
       }
       if (grabs !== undefined && grabs !== null) {
-        rows.push({ label: "Grabs", value: String(grabs) });
+        rows.push({ label: 'Grabs', value: String(grabs) });
       }
 
       let sizeTooltipContent: React.ReactNode = null;
@@ -298,9 +278,7 @@ export const ReleaseCell = ({
           <div className="flex max-w-xs flex-col gap-1">
             {rows.map((row) => (
               <div key={row.label} className="flex gap-2">
-                <span className="shrink-0 text-gray-400 dark:text-gray-500">
-                  {row.label}:
-                </span>
+                <span className="shrink-0 text-gray-400 dark:text-gray-500">{row.label}:</span>
                 <span className="truncate">{row.value}</span>
               </div>
             ))}
@@ -315,9 +293,7 @@ export const ReleaseCell = ({
       const sizeText = <span>{displayValue}</span>;
 
       return (
-        <div
-          className={`flex items-center ${alignClass} text-xs text-gray-600 dark:text-gray-300`}
-        >
+        <div className={`flex items-center ${alignClass} text-xs text-gray-600 dark:text-gray-300`}>
           {sizeTooltipContent ? (
             <Tooltip content={sizeTooltipContent} position="left">
               {sizeText}
@@ -329,7 +305,7 @@ export const ReleaseCell = ({
       );
     }
 
-    case "peers": {
+    case 'peers': {
       // Peers display: "S/L" string with badge colored by seeder count
       // Color logic: 0 = red, 1-10 = yellow, 10+ = blue
       const seeders = release.seeders;
@@ -353,18 +329,16 @@ export const ReleaseCell = ({
       // Determine color based on seeder count
       let badgeColors: string;
       if (seeders >= 10) {
-        badgeColors = "bg-blue-500/20 text-blue-700 dark:text-blue-300";
+        badgeColors = 'bg-blue-500/20 text-blue-700 dark:text-blue-300';
       } else if (seeders >= 1) {
-        badgeColors = "bg-yellow-500/20 text-yellow-700 dark:text-yellow-300";
+        badgeColors = 'bg-yellow-500/20 text-yellow-700 dark:text-yellow-300';
       } else {
-        badgeColors = "bg-red-500/20 text-red-700 dark:text-red-300";
+        badgeColors = 'bg-red-500/20 text-red-700 dark:text-red-300';
       }
 
       if (compact) {
         return (
-          <span
-            className={`font-medium ${badgeColors.split(" ").slice(1).join(" ")}`}
-          >
+          <span className={`font-medium ${badgeColors.split(' ').slice(1).join(' ')}`}>
             {peersValue}
           </span>
         );
@@ -380,15 +354,15 @@ export const ReleaseCell = ({
       );
     }
 
-    case "indexer_protocol": {
+    case 'indexer_protocol': {
       // Indexer name with colored dot indicating protocol (torrent/usenet) and peers count
       const protocol = release.protocol as string | undefined;
       const dotColor = getProtocolDotColor(protocol);
-      let protocolLabel = protocol || "Unknown";
-      if (protocol === "torrent") {
-        protocolLabel = "Torrent";
-      } else if (protocol === "nzb") {
-        protocolLabel = "Usenet";
+      let protocolLabel = protocol || 'Unknown';
+      if (protocol === 'torrent') {
+        protocolLabel = 'Torrent';
+      } else if (protocol === 'nzb') {
+        protocolLabel = 'Usenet';
       }
       const peers = release.peers;
 
@@ -408,40 +382,28 @@ export const ReleaseCell = ({
         <div
           className={`flex items-center ${alignClass} gap-1.5 truncate text-xs text-gray-600 dark:text-gray-300`}
         >
-          <span
-            className={`h-2 w-2 shrink-0 rounded-full ${dotColor}`}
-            title={protocolLabel}
-          />
+          <span className={`h-2 w-2 shrink-0 rounded-full ${dotColor}`} title={protocolLabel} />
           {/* Titled because one tracker can appear as several indexer entries whose
               names share a prefix, and truncation would make the rows look identical */}
           <span className="truncate" title={displayValue}>
             {displayValue}
           </span>
-          {peers && (
-            <span className="shrink-0 text-gray-400 dark:text-gray-500">
-              {peers}
-            </span>
-          )}
+          {peers && <span className="shrink-0 text-gray-400 dark:text-gray-500">{peers}</span>}
         </div>
       );
     }
 
-    case "flag_icon": {
+    case 'flag_icon': {
       // Colored badge showing FL, VIP, or both
       if (!cellValue || cellValue === column.fallback) {
         if (compact) return null;
         return <div className={`flex items-center ${alignClass}`} />;
       }
 
-      const flagColor = getColorStyleFromHint(cellValue, {
-        type: "map",
-        value: "flags",
-      });
+      const flagColor = getColorStyleFromHint(cellValue, { type: 'map', value: 'flags' });
 
       if (compact) {
-        return (
-          <span className={`${flagColor.text} font-medium`}>{cellValue}</span>
-        );
+        return <span className={`${flagColor.text} font-medium`}>{cellValue}</span>;
       }
       return (
         <div className={`flex items-center ${alignClass}`}>
@@ -454,11 +416,11 @@ export const ReleaseCell = ({
       );
     }
 
-    case "format_content_type": {
+    case 'format_content_type': {
       // Content type icon + format badge combined
       // Shows primary format as badge with colored dots for additional formats
       const contentType = release.content_type;
-      const isAudiobook = contentType === "audiobook";
+      const isAudiobook = contentType === 'audiobook';
       const formats = toStringArray(release.extra?.formats);
       const primaryFormat = formats?.[0] || null;
       const additionalFormats = formats?.slice(1) || [];
@@ -466,13 +428,9 @@ export const ReleaseCell = ({
       // The indexer named a format Shelfmark can't process (e.g. MAM "[ENG / MP4]").
       // Downloading it would only fail post-processing, so warn instead of showing the
       // bare content-type icon that makes it look like any other result.
-      const unrecognizedFormats = primaryFormat
-        ? []
-        : getUnrecognizedReleaseFormats(release);
+      const unrecognizedFormats = primaryFormat ? [] : getUnrecognizedReleaseFormats(release);
       if (unrecognizedFormats.length > 0) {
-        const unsupportedLabel = unrecognizedFormats
-          .map((fmt) => fmt.toUpperCase())
-          .join(", ");
+        const unsupportedLabel = unrecognizedFormats.map((fmt) => fmt.toUpperCase()).join(', ');
         const unsupportedTitle = `Unsupported format (${unsupportedLabel}) - Shelfmark cannot process this release`;
         if (compact) {
           return (
@@ -481,16 +439,12 @@ export const ReleaseCell = ({
               title={unsupportedTitle}
             >
               {unrecognizedFormats[0].toUpperCase()}
-              {unrecognizedFormats.length > 1 &&
-                ` +${unrecognizedFormats.length - 1}`}
+              {unrecognizedFormats.length > 1 && ` +${unrecognizedFormats.length - 1}`}
             </span>
           );
         }
         return (
-          <div
-            className="flex items-center justify-start"
-            title={unsupportedTitle}
-          >
+          <div className="flex items-center justify-start" title={unsupportedTitle}>
             <span className="inline-flex items-center gap-1">
               <span className="w-13 rounded-lg bg-amber-500/20 py-0.5 text-center text-[10px] font-semibold tracking-wide whitespace-nowrap text-amber-700 sm:text-[11px] dark:text-amber-400">
                 {unrecognizedFormats[0].toUpperCase()}
@@ -505,14 +459,9 @@ export const ReleaseCell = ({
 
       // Use blue for book, violet for audiobook when no format specified
       const noFormatStyle = isAudiobook
-        ? {
-            bg: "bg-violet-500/20",
-            text: "text-violet-600 dark:text-violet-400",
-          }
-        : { bg: "bg-blue-500/20", text: "text-blue-600 dark:text-blue-400" };
-      const colorStyle = primaryFormat
-        ? getFormatColor(primaryFormat)
-        : noFormatStyle;
+        ? { bg: 'bg-violet-500/20', text: 'text-violet-600 dark:text-violet-400' }
+        : { bg: 'bg-blue-500/20', text: 'text-blue-600 dark:text-blue-400' };
+      const colorStyle = primaryFormat ? getFormatColor(primaryFormat) : noFormatStyle;
 
       // Build rich tooltip content for formats (if multiple)
       let tooltipContent: React.ReactNode = null;
@@ -572,7 +521,7 @@ export const ReleaseCell = ({
           return (
             <span
               className="inline-flex items-center text-gray-500"
-              title={isAudiobook ? "Audiobook" : "Book"}
+              title={isAudiobook ? 'Audiobook' : 'Book'}
             >
               {icon}
             </span>
@@ -581,13 +530,10 @@ export const ReleaseCell = ({
         // Simple text tooltip for compact mode
         const compactTooltip =
           formats && formats.length > 1
-            ? formats.map((fmt) => fmt.toUpperCase()).join(", ")
+            ? formats.map((fmt) => fmt.toUpperCase()).join(', ')
             : undefined;
         return (
-          <span
-            className={column.uppercase ? "uppercase" : ""}
-            title={compactTooltip}
-          >
+          <span className={column.uppercase ? 'uppercase' : ''} title={compactTooltip}>
             {primaryFormat.toUpperCase()}
             {additionalFormats.length > 0 && ` +${additionalFormats.length}`}
           </span>
@@ -599,7 +545,7 @@ export const ReleaseCell = ({
         return (
           <div
             className="flex items-center justify-start"
-            title={isAudiobook ? "Audiobook" : "Book"}
+            title={isAudiobook ? 'Audiobook' : 'Book'}
           >
             <span
               className={`${colorStyle.bg} ${colorStyle.text} inline-flex w-13 items-center justify-center rounded-lg py-0.5 text-[10px] font-semibold sm:text-[11px]`}
@@ -639,23 +585,20 @@ export const ReleaseCell = ({
       );
     }
 
-    case "number":
+    case 'number':
       if (compact) {
         return <span>{displayValue}</span>;
       }
       return (
-        <div
-          className={`flex items-center ${alignClass} text-xs text-gray-600 dark:text-gray-300`}
-        >
+        <div className={`flex items-center ${alignClass} text-xs text-gray-600 dark:text-gray-300`}>
           {displayValue}
         </div>
       );
 
-    case "text":
+    case 'text':
     default: {
       // Check if this is a server column with online status data
-      const isServerColumn =
-        column.key === "extra.server" && onlineServers !== undefined;
+      const isServerColumn = column.key === 'extra.server' && onlineServers !== undefined;
       const isOnline = isServerColumn && onlineServers?.includes(cellValue);
 
       if (compact) {
@@ -663,8 +606,8 @@ export const ReleaseCell = ({
           return (
             <span className="inline-flex items-center gap-1">
               <span
-                className={`h-1.5 w-1.5 shrink-0 rounded-full ${isOnline ? "bg-emerald-500" : "bg-gray-400"}`}
-                title={isOnline ? "Online" : "Offline"}
+                className={`h-1.5 w-1.5 shrink-0 rounded-full ${isOnline ? 'bg-emerald-500' : 'bg-gray-400'}`}
+                title={isOnline ? 'Online' : 'Offline'}
               />
               {displayValue}
             </span>
@@ -679,8 +622,8 @@ export const ReleaseCell = ({
         >
           {isServerColumn && (
             <span
-              className={`mr-1.5 h-2 w-2 shrink-0 rounded-full ${isOnline ? "bg-emerald-500" : "bg-gray-400"}`}
-              title={isOnline ? "Online" : "Offline"}
+              className={`mr-1.5 h-2 w-2 shrink-0 rounded-full ${isOnline ? 'bg-emerald-500' : 'bg-gray-400'}`}
+              title={isOnline ? 'Online' : 'Offline'}
             />
           )}
           {displayValue}

--- a/src/frontend/src/tests/releaseFormats.test.ts
+++ b/src/frontend/src/tests/releaseFormats.test.ts
@@ -1,70 +1,63 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect } from 'vitest';
 
-import type { Release } from "../types";
-import {
-  getReleaseFormats,
-  getUnrecognizedReleaseFormats,
-} from "../utils/releaseFormats";
+import type { Release } from '../types';
+import { getReleaseFormats, getUnrecognizedReleaseFormats } from '../utils/releaseFormats';
 
 function buildRelease(overrides: Partial<Release>): Release {
   return {
-    source: "prowlarr",
-    source_id: "release-1",
-    title: "Test Release",
+    source: 'prowlarr',
+    source_id: 'release-1',
+    title: 'Test Release',
     ...overrides,
   };
 }
 
-describe("releaseFormats.getReleaseFormats", () => {
-  it("returns primary and extra formats in order, normalized and deduplicated", () => {
+describe('releaseFormats.getReleaseFormats', () => {
+  it('returns primary and extra formats in order, normalized and deduplicated', () => {
     const release = buildRelease({
-      format: "AZW3",
-      extra: { formats: ["MOBI", "EPUB", "azw3", "  mobi  "] },
+      format: 'AZW3',
+      extra: { formats: ['MOBI', 'EPUB', 'azw3', '  mobi  '] },
     });
 
-    expect(getReleaseFormats(release)).toEqual(["azw3", "mobi", "epub"]);
+    expect(getReleaseFormats(release)).toEqual(['azw3', 'mobi', 'epub']);
   });
 
-  it("uses extra formats when primary format is missing", () => {
+  it('uses extra formats when primary format is missing', () => {
     const release = buildRelease({
-      extra: { formats: ["EPUB", "MOBI"] },
+      extra: { formats: ['EPUB', 'MOBI'] },
     });
 
-    expect(getReleaseFormats(release)).toEqual(["epub", "mobi"]);
+    expect(getReleaseFormats(release)).toEqual(['epub', 'mobi']);
   });
 
-  it("supports legacy string value in extra.formats", () => {
+  it('supports legacy string value in extra.formats', () => {
     const release = buildRelease({
-      extra: { formats: "PDF" },
+      extra: { formats: 'PDF' },
     });
 
-    expect(getReleaseFormats(release)).toEqual(["pdf"]);
+    expect(getReleaseFormats(release)).toEqual(['pdf']);
   });
 });
 
-describe("releaseFormats.getUnrecognizedReleaseFormats", () => {
-  it("returns normalized, deduplicated unrecognized formats from extra", () => {
+describe('releaseFormats.getUnrecognizedReleaseFormats', () => {
+  it('returns normalized, deduplicated unrecognized formats from extra', () => {
     const release = buildRelease({
-      extra: { unrecognized_formats: ["MP4", " mp4 ", "WEBM"] },
+      extra: { unrecognized_formats: ['MP4', ' mp4 ', 'WEBM'] },
     });
 
-    expect(getUnrecognizedReleaseFormats(release)).toEqual(["mp4", "webm"]);
+    expect(getUnrecognizedReleaseFormats(release)).toEqual(['mp4', 'webm']);
   });
 
-  it("accepts a single string value", () => {
-    expect(
-      getUnrecognizedReleaseFormats(
-        buildRelease({ extra: { unrecognized_formats: "MP4" } }),
-      ),
-    ).toEqual(["mp4"]);
+  it('accepts a single string value', () => {
+    const release = buildRelease({ extra: { unrecognized_formats: 'MP4' } });
+
+    expect(getUnrecognizedReleaseFormats(release)).toEqual(['mp4']);
   });
 
-  it("returns an empty list when nothing was flagged", () => {
+  it('returns an empty list when nothing was flagged', () => {
     expect(getUnrecognizedReleaseFormats(buildRelease({}))).toEqual([]);
     expect(
-      getUnrecognizedReleaseFormats(
-        buildRelease({ extra: { unrecognized_formats: null } }),
-      ),
+      getUnrecognizedReleaseFormats(buildRelease({ extra: { unrecognized_formats: null } })),
     ).toEqual([]);
   });
 });

--- a/src/frontend/src/tests/releaseFormats.test.ts
+++ b/src/frontend/src/tests/releaseFormats.test.ts
@@ -1,40 +1,70 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 
-import type { Release } from '../types';
-import { getReleaseFormats } from '../utils/releaseFormats';
+import type { Release } from "../types";
+import {
+  getReleaseFormats,
+  getUnrecognizedReleaseFormats,
+} from "../utils/releaseFormats";
 
 function buildRelease(overrides: Partial<Release>): Release {
   return {
-    source: 'prowlarr',
-    source_id: 'release-1',
-    title: 'Test Release',
+    source: "prowlarr",
+    source_id: "release-1",
+    title: "Test Release",
     ...overrides,
   };
 }
 
-describe('releaseFormats.getReleaseFormats', () => {
-  it('returns primary and extra formats in order, normalized and deduplicated', () => {
+describe("releaseFormats.getReleaseFormats", () => {
+  it("returns primary and extra formats in order, normalized and deduplicated", () => {
     const release = buildRelease({
-      format: 'AZW3',
-      extra: { formats: ['MOBI', 'EPUB', 'azw3', '  mobi  '] },
+      format: "AZW3",
+      extra: { formats: ["MOBI", "EPUB", "azw3", "  mobi  "] },
     });
 
-    expect(getReleaseFormats(release)).toEqual(['azw3', 'mobi', 'epub']);
+    expect(getReleaseFormats(release)).toEqual(["azw3", "mobi", "epub"]);
   });
 
-  it('uses extra formats when primary format is missing', () => {
+  it("uses extra formats when primary format is missing", () => {
     const release = buildRelease({
-      extra: { formats: ['EPUB', 'MOBI'] },
+      extra: { formats: ["EPUB", "MOBI"] },
     });
 
-    expect(getReleaseFormats(release)).toEqual(['epub', 'mobi']);
+    expect(getReleaseFormats(release)).toEqual(["epub", "mobi"]);
   });
 
-  it('supports legacy string value in extra.formats', () => {
+  it("supports legacy string value in extra.formats", () => {
     const release = buildRelease({
-      extra: { formats: 'PDF' },
+      extra: { formats: "PDF" },
     });
 
-    expect(getReleaseFormats(release)).toEqual(['pdf']);
+    expect(getReleaseFormats(release)).toEqual(["pdf"]);
+  });
+});
+
+describe("releaseFormats.getUnrecognizedReleaseFormats", () => {
+  it("returns normalized, deduplicated unrecognized formats from extra", () => {
+    const release = buildRelease({
+      extra: { unrecognized_formats: ["MP4", " mp4 ", "WEBM"] },
+    });
+
+    expect(getUnrecognizedReleaseFormats(release)).toEqual(["mp4", "webm"]);
+  });
+
+  it("accepts a single string value", () => {
+    expect(
+      getUnrecognizedReleaseFormats(
+        buildRelease({ extra: { unrecognized_formats: "MP4" } }),
+      ),
+    ).toEqual(["mp4"]);
+  });
+
+  it("returns an empty list when nothing was flagged", () => {
+    expect(getUnrecognizedReleaseFormats(buildRelease({}))).toEqual([]);
+    expect(
+      getUnrecognizedReleaseFormats(
+        buildRelease({ extra: { unrecognized_formats: null } }),
+      ),
+    ).toEqual([]);
   });
 });

--- a/src/frontend/src/utils/releaseFormats.ts
+++ b/src/frontend/src/utils/releaseFormats.ts
@@ -1,7 +1,7 @@
-import type { Release } from "../types";
+import type { Release } from '../types';
 
 function normalizeFormatValue(value: unknown): string | null {
-  if (typeof value !== "string") {
+  if (typeof value !== 'string') {
     return null;
   }
 

--- a/src/frontend/src/utils/releaseFormats.ts
+++ b/src/frontend/src/utils/releaseFormats.ts
@@ -1,7 +1,7 @@
-import type { Release } from '../types';
+import type { Release } from "../types";
 
 function normalizeFormatValue(value: unknown): string | null {
-  if (typeof value !== 'string') {
+  if (typeof value !== "string") {
     return null;
   }
 
@@ -30,6 +30,30 @@ export function getReleaseFormats(release: Release): string[] {
   } else {
     addFormat(extraFormats);
   }
+
+  return formats;
+}
+
+/**
+ * Format tokens the indexer declared but the backend could not map to a known
+ * book/audiobook format (e.g. MyAnonamouse "[ENG / MP4]"). Such a release will
+ * download but fail post-processing, so the UI warns instead of showing a bare
+ * content-type icon.
+ */
+export function getUnrecognizedReleaseFormats(release: Release): string[] {
+  const raw = release.extra?.unrecognized_formats;
+  const values = Array.isArray(raw) ? raw : [raw];
+  const formats: string[] = [];
+  const seen = new Set<string>();
+
+  values.forEach((value) => {
+    const normalized = normalizeFormatValue(value);
+    if (!normalized || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    formats.push(normalized);
+  });
 
   return formats;
 }

--- a/tests/prowlarr/test_source.py
+++ b/tests/prowlarr/test_source.py
@@ -1398,3 +1398,80 @@ class TestSearchBudgetScalesWithIndexerTimeout:
 
     def test_budget_stays_under_the_gunicorn_worker_timeout(self):
         assert _search_budget_seconds(300) == 240.0
+
+
+class TestSplitMamFormats:
+    """MAM's structured "[LANG / FORMATS]" bracket, split into known vs unknown tokens."""
+
+    def test_recognized_only(self):
+        from shelfmark.release_sources.prowlarr.source import _split_mam_formats
+
+        assert _split_mam_formats("Title by Author [ENG / EPUB MOBI]") == (["epub", "mobi"], [])
+
+    def test_unrecognized_only_is_surfaced(self):
+        from shelfmark.release_sources.prowlarr.source import _split_mam_formats
+
+        assert _split_mam_formats("The Martian by Andy Weir [ENG / MP4]") == ([], ["mp4"])
+
+    def test_mixed_keeps_both_sides(self):
+        from shelfmark.release_sources.prowlarr.source import _split_mam_formats
+
+        assert _split_mam_formats("Title [ENG / M4B MP4]") == (["m4b"], ["mp4"])
+
+    def test_no_structured_bracket(self):
+        from shelfmark.release_sources.prowlarr.source import _split_mam_formats
+
+        assert _split_mam_formats("Title [VIP]") == ([], [])
+        assert _split_mam_formats("") == ([], [])
+
+    def test_extract_mam_formats_still_returns_recognized(self):
+        from shelfmark.release_sources.prowlarr.source import _extract_mam_formats
+
+        assert _extract_mam_formats("Title [ENG / MP3]") == ["mp3"]
+        assert _extract_mam_formats("Title [ENG / MP4]") == []
+
+
+class TestUnrecognizedFormatOnRelease:
+    def _result(self, title: str) -> dict:
+        return {
+            "title": title,
+            "guid": "https://www.myanonamouse.net/t/627978",
+            "indexer": "MyAnonamouse",
+            "indexerId": 1,
+            "protocol": "torrent",
+            "size": 320000000,
+            "seeders": 800,
+            "leechers": 0,
+            "categories": [{"id": 3030}],
+        }
+
+    def test_unrecognized_format_lands_in_extra(self):
+        from shelfmark.release_sources.prowlarr.source import _prowlarr_result_to_release
+
+        release = _prowlarr_result_to_release(
+            self._result("The Martian by Andy Weir [ENG / MP4]"),
+            "audiobook",
+            enable_format_detection=True,
+        )
+        assert release.format is None
+        assert release.extra["formats"] is None
+        assert release.extra["unrecognized_formats"] == ["mp4"]
+
+    def test_recognized_format_leaves_unrecognized_empty(self):
+        from shelfmark.release_sources.prowlarr.source import _prowlarr_result_to_release
+
+        release = _prowlarr_result_to_release(
+            self._result("The Martian by Andy Weir [ENG / M4B]"),
+            "audiobook",
+            enable_format_detection=True,
+        )
+        assert release.format == "m4b"
+        assert release.extra["unrecognized_formats"] is None
+
+    def test_not_populated_without_format_detection(self):
+        from shelfmark.release_sources.prowlarr.source import _prowlarr_result_to_release
+
+        release = _prowlarr_result_to_release(
+            self._result("The Martian by Andy Weir [ENG / MP4]"), "audiobook"
+        )
+        assert release.extra["unrecognized_formats"] is None


### PR DESCRIPTION
## Problem

Companion to #1264, but general rather than mp4-specific.

MyAnonamouse titles carry a structured `[LANG / FORMATS]` bracket that `_extract_mam_formats` parses. When every token in it is something Shelfmark doesn't know — e.g. `The Martian by Andy Weir [ENG / MP4]` — the release is rendered with **no format chip at all**, just the generic headphones/book icon with an "Audiobook" tooltip. To a user that looks like an ordinary result. It downloads fine and then fails post-processing with *"No book files found in download"*.

The backend already *had* the signal (a format token it couldn't map); it just threw it away.

## Change

**Backend** (`shelfmark/release_sources/prowlarr/source.py`)
- `_split_mam_formats(raw_title) -> (recognized, unrecognized)` replaces the body of `_extract_mam_formats`, which is kept as a thin wrapper returning `recognized` so nothing else changes.
- Releases gain `extra["unrecognized_formats"]` (list, or `None` when empty / when format detection is off).

**Frontend**
- `getUnrecognizedReleaseFormats(release)` in `utils/releaseFormats.ts` (normalised + deduped, same shape as `getReleaseFormats`).
- `ReleaseCell` `format_content_type`: when there is **no** recognised format but the indexer named one, render an amber `MP4  Unsupported` badge (compact view: amber `MP4`) with tooltip *"Unsupported format (MP4) - Shelfmark cannot process this release"*. When a recognised format exists the existing badge is untouched, even if extra unknown tokens were present.

Only the chip changes — the download button still works, so a user can still grab and hand-process the files if they want to. Happy to disable the button instead if you'd prefer.

## Tests

- `tests/prowlarr/test_source.py`: `TestSplitMamFormats` (recognised / unrecognised / mixed / no bracket / wrapper compat) and `TestUnrecognizedFormatOnRelease` (lands in `extra`, empty when recognised, absent without format detection).
- `src/frontend/src/tests/releaseFormats.test.ts`: 3 cases for the new helper.
- `ruff check` clean; `pytest tests/prowlarr -m "not integration"` 511 passed; `tsc --noEmit`, `oxlint --deny warnings`, `vitest` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
