### PR TITLE
fix: share rotating log file handlers

### DIFF
--- a/shelfmark/core/logger.py
+++ b/shelfmark/core/logger.py
@@ -4,12 +4,17 @@ import logging
 import sys
 from collections.abc import Mapping
 from logging.handlers import RotatingFileHandler
+from threading import Lock
 from typing import TYPE_CHECKING
 
 from shelfmark.config.env import ENABLE_LOGGING, LOG_FILE, LOG_LEVEL
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+_file_handlers: dict[Path, RotatingFileHandler] = {}
+_file_handlers_lock = Lock()
 
 
 class CustomLogger(logging.Logger):
@@ -122,6 +127,22 @@ def _normalize_log_extra(value: object) -> Mapping[str, object] | None:
     return None
 
 
+def _get_file_handler(log_file: Path, formatter: logging.Formatter) -> RotatingFileHandler:
+    """Return the process-wide rotating handler for a log file."""
+    with _file_handlers_lock:
+        handler = _file_handlers.get(log_file)
+        if handler is None:
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+            handler = RotatingFileHandler(
+                log_file,
+                maxBytes=10485760,  # 10MB
+                backupCount=5,
+            )
+            handler.setFormatter(formatter)
+            _file_handlers[log_file] = handler
+        return handler
+
+
 def setup_logger(name: str, log_file: Path = LOG_FILE) -> CustomLogger:
     """Set up and configure a logger instance.
 
@@ -163,16 +184,7 @@ def setup_logger(name: str, log_file: Path = LOG_FILE) -> CustomLogger:
     # File handler if log file is specified
     try:
         if ENABLE_LOGGING:
-            # Create log directory if it doesn't exist
-            log_dir = log_file.parent
-            log_dir.mkdir(parents=True, exist_ok=True)
-            file_handler = RotatingFileHandler(
-                log_file,
-                maxBytes=10485760,  # 10MB
-                backupCount=5,
-            )
-            file_handler.setFormatter(formatter)
-            logger.addHandler(file_handler)
+            logger.addHandler(_get_file_handler(log_file, formatter))
     except (OSError, TypeError, ValueError) as e:
         logger.error_trace(f"Failed to create log file: {e}", exc_info=True)
 

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -1,0 +1,60 @@
+"""Tests for Shelfmark's logging configuration."""
+
+from logging.handlers import RotatingFileHandler
+
+import shelfmark.core.logger as logger_module
+
+
+def test_setup_logger_shares_file_handler(monkeypatch, tmp_path):
+    """Module loggers must not open the shared log file independently."""
+    monkeypatch.setattr(logger_module, "ENABLE_LOGGING", True)
+    log_file = tmp_path / "shelfmark.log"
+
+    first_logger = logger_module.setup_logger("shelfmark.test.first", log_file)
+    second_logger = logger_module.setup_logger("shelfmark.test.second", log_file)
+
+    first_handler = next(
+        handler for handler in first_logger.handlers if isinstance(handler, RotatingFileHandler)
+    )
+    second_handler = next(
+        handler for handler in second_logger.handlers if isinstance(handler, RotatingFileHandler)
+    )
+
+    assert first_handler is second_handler
+    assert first_handler.stream is not None
+    assert second_handler.stream is not None
+    assert first_handler.stream.fileno() == second_handler.stream.fileno()
+
+    first_logger.removeHandler(first_handler)
+    second_logger.removeHandler(second_handler)
+    with logger_module._file_handlers_lock:
+        logger_module._file_handlers.pop(log_file)
+    first_handler.close()
+
+
+def test_setup_logger_keeps_separate_handlers_for_separate_files(monkeypatch, tmp_path):
+    """Explicitly different log destinations must remain independent."""
+    monkeypatch.setattr(logger_module, "ENABLE_LOGGING", True)
+    first_file = tmp_path / "first.log"
+    second_file = tmp_path / "second.log"
+
+    first_logger = logger_module.setup_logger("shelfmark.test.first_file", first_file)
+    second_logger = logger_module.setup_logger("shelfmark.test.second_file", second_file)
+
+    first_handler = next(
+        handler for handler in first_logger.handlers if isinstance(handler, RotatingFileHandler)
+    )
+    second_handler = next(
+        handler for handler in second_logger.handlers if isinstance(handler, RotatingFileHandler)
+    )
+
+    assert first_handler is not second_handler
+
+    for logger, handler, log_file in (
+        (first_logger, first_handler, first_file),
+        (second_logger, second_handler, second_file),
+    ):
+        logger.removeHandler(handler)
+        with logger_module._file_handlers_lock:
+            logger_module._file_handlers.pop(log_file)
+        handler.close()


### PR DESCRIPTION
This patch shares (for each log file) the `RotatingFileHandler` for logging across all modules, reducing the number of open file descriptors from ~78 to 1.

I had originally assumed this issue was a resource leak, but it seems to just be a large fixed number of file descriptors. So this change mostly just (1) shrinks the number of open file descriptors to a reasonable level and (2) prevents two modules in the same process competing to write to a log file.