### PR TITLE
feat: add extensible direct-download providers and OceanofPDF support

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -62,6 +62,14 @@ jobs:
           - target: shelfmark-lite
             image_name_suffix: "-lite"
     steps:
+      - name: Normalize Docker image name
+        id: image_name
+        env:
+          RAW_IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: |
+          NORMALIZED_IMAGE_NAME=$(printf '%s' "$RAW_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
+          echo "name=$NORMALIZED_IMAGE_NAME" >> "$GITHUB_OUTPUT"
+
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
@@ -86,7 +94,7 @@ jobs:
           # standard org.opencontainers.image.* annotations, including `created`.
           DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_name_suffix }}
+          images: ${{ env.REGISTRY }}/${{ steps.image_name.outputs.name }}${{ matrix.image_name_suffix }}
           tags: |
             type=raw,value=dev,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
@@ -94,6 +102,11 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=ref,event=tag
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -113,11 +126,22 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
 
+      - name: Verify multi-platform image
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ steps.image_name.outputs.name }}${{ matrix.image_name_suffix }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          INSPECTION=$(docker buildx imagetools inspect "${IMAGE}@${DIGEST}")
+          echo "$INSPECTION"
+          grep -Eq 'Platform:[[:space:]]+linux/amd64([[:space:]]|$)' <<< "$INSPECTION"
+          grep -Eq 'Platform:[[:space:]]+linux/arm64(/v8)?([[:space:]]|$)' <<< "$INSPECTION"
+
       - name: Generate artifact attestation for ${{ matrix.target }} image
         if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_name_suffix }}
+          subject-name: ${{ env.REGISTRY }}/${{ steps.image_name.outputs.name }}${{ matrix.image_name_suffix }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
@@ -144,13 +168,21 @@ jobs:
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Create legacy aliases
+        env:
+          RAW_IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          RAW_LEGACY_OWNER: ${{ github.repository_owner }}
         run: |
+          # Docker repository paths must be lowercase. GitHub owner names retain
+          # their display casing (for example, "TomJansen"), so normalize them.
+          IMAGE_NAME=$(printf '%s' "$RAW_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
+          LEGACY_OWNER=$(printf '%s' "$RAW_LEGACY_OWNER" | tr '[:upper:]' '[:lower:]')
+
           # Current image names (follows repo name)
-          STANDARD="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          LITE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-lite"
+          STANDARD="${{ env.REGISTRY }}/${IMAGE_NAME}"
+          LITE="${{ env.REGISTRY }}/${IMAGE_NAME}-lite"
 
           # Legacy image names (hardcoded for backwards compatibility)
-          LEGACY="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.LEGACY_NAME }}"
+          LEGACY="${{ env.REGISTRY }}/${LEGACY_OWNER}/${{ env.LEGACY_NAME }}"
           LEGACY_TOR="${LEGACY}-tor"
           LEGACY_EXTBP="${LEGACY}-extbp"
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -2176,7 +2176,7 @@ Enable Moly.hu as a metadata provider for book searches
 | `DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH` | When language metadata is missing or unknown, parse the distant path (file path shown in search results) for language tags like [BD FR] or [En]. Also enables local language filtering so lgli files without AA language metadata are not excluded before the distant path can be checked. | boolean | `false` |
 | `AA_DONATOR_KEY` | Enables fast download access on AA. Get this from your donator account page. | string (secret) | _none_ |
 | `FAST_SOURCES_DISPLAY` | Always tried first, no waiting or bypass required. | JSON array | _see UI for defaults_ |
-| `SOURCE_PRIORITY` | Fallback sources, may have waiting. Requires bypasser. Drag to reorder. | JSON array | _see UI for defaults_ |
+| `SOURCE_PRIORITY` | Fallback sources, some with waiting or bypass requirements. Drag to reorder. | JSON array | _see UI for defaults_ |
 | `MAX_RETRY` | Maximum retry attempts for failed downloads. | number | `10` |
 | `DEFAULT_SLEEP` | Wait time between download retry attempts. | number | `5` |
 | `RELEASE_SEARCH_TIMEOUT` | How long one release search may run before it gives up and reports why. A first search on a cold start pays for a browser solve, so leave room for one. If you use a reverse proxy, its read timeout should be at least this high or it will cut the search off with a 504 first. | number | `300` |
@@ -2233,7 +2233,7 @@ Always tried first, no waiting or bypass required.
 
 **Slow downloads**
 
-Fallback sources, may have waiting. Requires bypasser. Drag to reorder.
+Fallback sources, some with waiting or bypass requirements. Drag to reorder.
 
 - **Type:** JSON array
 - **Default:** _see UI for defaults_
@@ -2433,6 +2433,7 @@ How long the bypass helper process may sit unused before it is shut down. Higher
 | `LIBGEN_MIRROR_URLS` | Mirrors are tried in the order you add them until one works. | string (comma-separated) | _empty list_ |
 | `ZLIB_MIRROR_URLS` | Only the first mirror in the list is used. | string (comma-separated) | _empty list_ |
 | `WELIB_MIRROR_URLS` | Only the first mirror in the list is used. | string (comma-separated) | _empty list_ |
+| `OCEANOFPDF_MIRROR_URLS` | Only the first mirror in the list is used for searches. | string (comma-separated) | _empty list_ |
 
 <details>
 <summary>Detailed descriptions</summary>
@@ -2479,6 +2480,15 @@ Only the first mirror in the list is used.
 **Welib**
 
 Only the first mirror in the list is used.
+
+- **Type:** string (comma-separated)
+- **Default:** _empty list_
+
+#### `OCEANOFPDF_MIRROR_URLS`
+
+**Mirrors**
+
+Only the first mirror in the list is used for searches.
 
 - **Type:** string (comma-separated)
 - **Default:** _empty list_

--- a/shelfmark/config/settings.py
+++ b/shelfmark/config/settings.py
@@ -1436,17 +1436,17 @@ def _get_fast_source_defaults() -> list[dict[str, str | bool]]:
 
 
 def _get_slow_source_options() -> list[dict[str, str | bool | None]]:
-    """Slow download sources - configurable order. All require bypasser."""
+    """Slow and fallback download sources in configurable order."""
     from shelfmark.core.config import config
     from shelfmark.core.mirrors import get_download_source_missing_mirror_reason
 
     bypass_enabled = config.get("USE_CF_BYPASS", True)
 
-    def _get_reason(source_id: str) -> str | None:
+    def _get_reason(source_id: str, *, requires_bypass: bool = True) -> str | None:
         mirror_reason = get_download_source_missing_mirror_reason(source_id)
         if mirror_reason:
             return mirror_reason
-        if not bypass_enabled:
+        if requires_bypass and not bypass_enabled:
             return "Requires Cloudflare bypass"
         return None
 
@@ -1479,6 +1479,13 @@ def _get_slow_source_options() -> list[dict[str, str | bool | None]]:
             "isLocked": _get_reason("zlib") is not None,
             "disabledReason": _get_reason("zlib"),
         },
+        {
+            "id": "oceanofpdf",
+            "label": "OceanofPDF",
+            "description": "Website downloads; bypass used when required",
+            "isLocked": _get_reason("oceanofpdf", requires_bypass=False) is not None,
+            "disabledReason": _get_reason("oceanofpdf", requires_bypass=False),
+        },
     ]
 
 
@@ -1491,6 +1498,7 @@ def _get_slow_source_defaults() -> list[dict[str, str | bool]]:
         {"id": "aa-slow-wait", "enabled": True},
         {"id": "welib", "enabled": _LEGACY_ALLOW_USE_WELIB},
         {"id": "zlib", "enabled": True},
+        {"id": "oceanofpdf", "enabled": True},
     ]
 
 
@@ -1540,7 +1548,9 @@ def download_source_settings() -> list[SettingsField]:
         OrderableListField(
             key="SOURCE_PRIORITY",
             label="Slow downloads",
-            description="Fallback sources, may have waiting. Requires bypasser. Drag to reorder.",
+            description=(
+                "Fallback sources, some with waiting or bypass requirements. Drag to reorder."
+            ),
             options=_get_slow_source_options,
             default=_get_slow_source_defaults(),
         ),
@@ -1720,6 +1730,7 @@ def _on_save_mirrors(values: dict[str, Any]) -> dict[str, Any]:
         "LIBGEN_MIRROR_URLS",
         "ZLIB_MIRROR_URLS",
         "WELIB_MIRROR_URLS",
+        "OCEANOFPDF_MIRROR_URLS",
     }
 
     for key in mirror_list_keys:
@@ -1804,6 +1815,19 @@ def mirror_settings() -> list[SettingsField]:
             label="Welib",
             description="Only the first mirror in the list is used.",
             placeholder="https://your-welib-mirror.example",
+        ),
+        # === OCEANOFPDF ===
+        HeadingField(
+            key="oceanofpdf_mirrors_heading",
+            title="OceanofPDF",
+            description="Add your own OceanofPDF mirror URL here.",
+        ),
+        TagListField(
+            key="OCEANOFPDF_MIRROR_URLS",
+            label="Mirrors",
+            description="Only the first mirror in the list is used for searches.",
+            placeholder="https://your-oceanofpdf-mirror.example",
+            default=[],
         ),
     ]
 

--- a/shelfmark/core/mirrors.py
+++ b/shelfmark/core/mirrors.py
@@ -36,6 +36,7 @@ _DOWNLOAD_SOURCE_MIRROR_LABELS = {
     "libgen": "LibGen",
     "zlib": "Z-Library",
     "welib": "Welib",
+    "oceanofpdf": "OceanofPDF",
 }
 
 
@@ -198,6 +199,22 @@ def has_welib_mirror_configuration() -> bool:
     return bool(get_welib_mirrors())
 
 
+def get_oceanofpdf_mirrors() -> list[str]:
+    """Get user-configured OceanofPDF mirrors, with the search mirror first."""
+    return _normalize_configured_urls(_get_config().get("OCEANOFPDF_MIRROR_URLS", None))
+
+
+def has_oceanofpdf_mirror_configuration() -> bool:
+    """Return True when at least one OceanofPDF mirror URL is configured."""
+    return bool(get_oceanofpdf_mirrors())
+
+
+def get_oceanofpdf_primary_url() -> str | None:
+    """Return the first configured OceanofPDF mirror, if present."""
+    mirrors = get_oceanofpdf_mirrors()
+    return mirrors[0] if mirrors else None
+
+
 def has_download_source_mirror_configuration(source_id: str) -> bool:
     """Return True when the requested direct-download source has mirror config."""
     if source_id in {"aa-fast", "aa-slow", "aa-slow-nowait", "aa-slow-wait"}:
@@ -208,6 +225,8 @@ def has_download_source_mirror_configuration(source_id: str) -> bool:
         return has_zlib_mirror_configuration()
     if source_id == "welib":
         return has_welib_mirror_configuration()
+    if source_id == "oceanofpdf":
+        return has_oceanofpdf_mirror_configuration()
     return False
 
 

--- a/shelfmark/core/onboarding.py
+++ b/shelfmark/core/onboarding.py
@@ -351,7 +351,7 @@ def get_release_source_selection_fields() -> list[SettingsField]:
                 {
                     "value": "direct_download",
                     "label": "Direct Download",
-                    "description": "Configure your own Anna's Archive mirror URLs for direct ebook downloads.",
+                    "description": "Configure your own mirror URLs for direct ebook downloads.",
                 },
                 {
                     "value": "prowlarr",
@@ -379,17 +379,43 @@ def get_direct_download_setup_fields() -> list[SettingsField]:
     fields: list[SettingsField] = [
         HeadingField(
             key="direct_download_setup_onboarding_heading",
-            title="Direct Download Setup",
+            title="Choose at least one download source",
             description=(
-                "Add at least one Anna's Archive mirror URL to enable Direct Download. If you "
-                "have an Anna's Archive donator key, you can add it here too. You can configure "
-                "alternative mirrors later in Settings."
+                "Add at least one Anna's Archive or OceanofPDF mirror URL to enable Direct "
+                "Download. You can configure additional mirrors later in Settings."
             ),
         )
     ]
-    fields.extend(_get_fields_from_tab("download_sources", ["AA_DONATOR_KEY"]))
     fields.extend(_get_fields_from_tab("mirrors", ["AA_MIRROR_URLS"]))
+    donator_key = _get_field_from_tab("download_sources", "AA_DONATOR_KEY")
+    if donator_key:
+        fields.append(
+            _clone_field_with_overrides(
+                donator_key,
+                label="Anna's Archive Donator Key (optional)",
+            )
+        )
+    fields.extend(_get_fields_from_tab("mirrors", ["OCEANOFPDF_MIRROR_URLS"]))
     return fields
+
+
+def get_direct_download_field_groups() -> list[dict[str, Any]]:
+    """Group direct-download settings by provider for the onboarding UI."""
+    return [
+        {
+            "id": "annas_archive",
+            "title": "Anna's Archive",
+            "description": "Configure mirror URLs and an optional donator API key.",
+            "field_keys": ["AA_MIRROR_URLS", "AA_DONATOR_KEY"],
+            "default_open": True,
+        },
+        {
+            "id": "oceanofpdf",
+            "title": "OceanOfPDF",
+            "description": "Configure the mirror URL used for searches and downloads.",
+            "field_keys": ["OCEANOFPDF_MIRROR_URLS"],
+        },
+    ]
 
 
 def get_direct_download_bypass_fields() -> list[SettingsField]:
@@ -501,6 +527,7 @@ def get_onboarding_steps() -> list[dict[str, Any]]:
             "title": "Direct Download Setup",
             "tab": "download_sources",
             "get_fields": get_direct_download_setup_fields,
+            "field_groups": get_direct_download_field_groups(),
             "show_when": [{"field": "SEARCH_MODE", "value": "direct"}],
         },
         {
@@ -515,6 +542,7 @@ def get_onboarding_steps() -> list[dict[str, Any]]:
             "title": "Direct Download Setup",
             "tab": "download_sources",
             "get_fields": get_direct_download_setup_fields,
+            "field_groups": get_direct_download_field_groups(),
             "show_when": [
                 {"field": "SEARCH_MODE", "value": "universal"},
                 {"field": ONBOARDING_RELEASE_SOURCES_KEY, "value": "direct_download"},
@@ -605,6 +633,17 @@ def get_onboarding_config() -> dict[str, Any]:
             step["showWhen"] = step_config["show_when"]
         if step_config.get("optional"):
             step["optional"] = True
+        if "field_groups" in step_config:
+            step["fieldGroups"] = [
+                {
+                    "id": group["id"],
+                    "title": group["title"],
+                    "description": group.get("description", ""),
+                    "fieldKeys": group["field_keys"],
+                    "defaultOpen": group.get("default_open", False),
+                }
+                for group in step_config["field_groups"]
+            ]
 
         steps.append(step)
 

--- a/shelfmark/release_sources/direct_download/README.md
+++ b/shelfmark/release_sources/direct_download/README.md
@@ -1,0 +1,35 @@
+# Direct Download website adapters
+
+`source.py` owns release-source integration; `handler.py` owns download routing
+and staging. `__init__.py` exposes the public API and triggers registration.
+`annas_archive.py` owns Anna's Archive search planning, parsing, page caching,
+and its MD5 mirror cascade. `oceanofpdf.py` owns OceanofPDF parsing and downloads.
+Both implement `DirectDownloadProvider` and join the same search and download
+lifecycle through `PROVIDER_TYPES` in `registry.py`.
+
+To add a website:
+
+1. Implement `DirectDownloadProvider` from `common.py` in a site-specific module. Keep HTML
+   selectors, URL recognition, and download resolution in that module.
+2. Use `parse_search_page` or `parse_search_items` with a site-specific extractor
+   returning `ParsedSearchResult`. These helpers normalize languages, filter
+   formats, and generate stable IDs per provider and format. Preserve native IDs
+   with `record_id` when available, as Anna's Archive does for MD5 records.
+3. Use provider-namespaced record IDs and set `source_url` to the user-facing
+   record URL. `parse_search_page` does the namespacing automatically when no
+   native `record_id` is supplied. URL recognition remains a compatibility fallback.
+4. Implement `download` to write to the supplied staging path and return the
+   successful URL (or `None`). Honor cancellation and forward progress/status
+   callbacks. Reuse `shelfmark.download.http` for supported HTTP and bypass flows.
+5. Add the provider class to `PROVIDER_TYPES` in `registry.py`, add its configuration if
+   needed, and cover parsing and download behavior with fixture-based tests.
+
+Adapters must not import `source.py`, `handler.py`, or `registry.py`; shared code belongs in `common.py`
+or the existing download utilities. A website adapter is internal to the
+`direct_download` release source, so it does not need `register_source` or
+`register_handler`.
+
+Providers receive the complete book and release-search plan, so Anna's Archive
+retains ISBN priority, localized-title variants, and language retries while simpler
+providers can derive one or more plain-text queries. Direct Download is available
+when it is enabled and at least one configured provider is enabled.

--- a/shelfmark/release_sources/direct_download/__init__.py
+++ b/shelfmark/release_sources/direct_download/__init__.py
@@ -1,0 +1,20 @@
+"""Direct Download release source and public entry points.
+
+Importing the source and handler classes registers them with Shelfmark.
+"""
+
+from shelfmark.release_sources.direct_download.annas_archive import search_books
+from shelfmark.release_sources.direct_download.common import DirectDownloadUnavailableError
+from shelfmark.release_sources.direct_download.handler import DirectDownloadHandler
+from shelfmark.release_sources.direct_download.source import DirectDownloadSource
+
+__all__ = [
+    "DirectDownloadUnavailableError",
+    "DirectDownloadHandler",
+    "DirectDownloadSource",
+    "SearchUnavailableError",
+    "search_books",
+]
+
+# Compatibility alias for integrations that imported the old module-level name.
+SearchUnavailableError = DirectDownloadUnavailableError

--- a/shelfmark/release_sources/direct_download/annas_archive.py
+++ b/shelfmark/release_sources/direct_download/annas_archive.py
@@ -1,9 +1,8 @@
-"""Direct download source - Anna's Archive/Libgen with fallback cascade."""
+"""Anna's Archive search, metadata parsing, and MD5 mirror download cascade."""
 
 import itertools
 import json
 import re
-import threading
 import time
 import unicodedata
 from contextlib import contextmanager
@@ -11,7 +10,7 @@ from contextvars import ContextVar
 from dataclasses import replace
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, NoReturn, TypedDict
+from typing import TYPE_CHECKING, NoReturn, TypedDict
 from urllib.parse import quote, urlparse
 
 import requests
@@ -19,30 +18,33 @@ from bs4 import BeautifulSoup, Tag
 from bs4.element import NavigableString
 
 from shelfmark.bypass.challenge import MAX_CHALLENGE_HTML_CHARS, challenge_marker
-from shelfmark.config.env import DEBUG_SKIP_SOURCES, TMP_DIR
+from shelfmark.config.env import DEBUG_SKIP_SOURCES
 from shelfmark.core import search_deadline
 from shelfmark.core.config import config
-from shelfmark.core.languages import language_alias_map
 from shelfmark.core.logger import setup_logger
-from shelfmark.core.models import DownloadTask, SearchFilters, build_filename
-from shelfmark.core.utils import CONTENT_TYPES, get_aa_content_type_dir
-from shelfmark.core.utils import is_audiobook as check_audiobook
+from shelfmark.core.models import SearchFilters
+from shelfmark.core.utils import CONTENT_TYPES
 from shelfmark.download import http as downloader
 from shelfmark.download import network
-from shelfmark.release_sources import (
-    BrowseRecord,
-    ColumnAlign,
-    ColumnColorHint,
-    ColumnRenderType,
-    ColumnSchema,
-    DownloadHandler,
-    Release,
-    ReleaseColumnConfig,
-    ReleaseProtocol,
-    ReleaseSource,
-    SourceUnavailableError,
-    register_handler,
-    register_source,
+from shelfmark.release_sources import BrowseRecord
+from shelfmark.release_sources.direct_download.common import (
+    MIN_VALID_FILE_SIZE as _MIN_VALID_FILE_SIZE,
+)
+from shelfmark.release_sources.direct_download.common import (
+    DirectDownloadUnavailableError,
+    ParsedSearchResult,
+    get_attr,
+    get_supported_formats,
+    html_response_text,
+    language_alias_to_code,
+    normalize_language_token,
+    normalize_requested_languages,
+    normalize_size,
+    parse_search_items,
+    parse_search_page,
+)
+from shelfmark.release_sources.direct_download.common import (
+    book_matches_requested_languages as _book_matches_requested_languages,
 )
 
 if TYPE_CHECKING:
@@ -65,18 +67,6 @@ class SourcePriorityEntry(TypedDict):
 
 def _raise_runtime_error(message: str) -> NoReturn:
     raise RuntimeError(message)
-
-
-def _coerce_str_list(value: object) -> list[str]:
-    """Return only string items from a config value."""
-    if not isinstance(value, list | tuple):
-        return []
-    return [item for item in value if isinstance(item, str)]
-
-
-def _get_supported_formats() -> list[str]:
-    """Return configured supported formats as a clean string list."""
-    return _coerce_str_list(config.SUPPORTED_FORMATS)
 
 
 def _parse_source_priority_entries(
@@ -108,13 +98,6 @@ def _parse_source_priority_entries(
     return entries
 
 
-def _html_response_text(response: str | tuple[str, str]) -> str:
-    """Extract the HTML body from downloader responses."""
-    if isinstance(response, tuple):
-        return response[0]
-    return response
-
-
 def _html_response_url(response: str | tuple[str, str]) -> str | None:
     """The URL that actually answered, when the downloader was asked to report it.
 
@@ -123,22 +106,6 @@ def _html_response_url(response: str | tuple[str, str]) -> str | None:
     if isinstance(response, tuple):
         return response[1] or None
     return None
-
-
-def _attr_to_str(value: object) -> str | None:
-    """Convert a BeautifulSoup attribute value to a plain string."""
-    if isinstance(value, str):
-        return value
-    if isinstance(value, list):
-        for item in value:
-            if isinstance(item, str):
-                return item
-    return None
-
-
-def _get_attr(tag: Tag, attr: str) -> str | None:
-    """Safely fetch a tag attribute as a string."""
-    return _attr_to_str(tag.get(attr))
 
 
 def _first_stripped_text(tag: Tag | None) -> str | None:
@@ -212,8 +179,8 @@ _DOWNLOAD_SOURCES = [
 ]
 
 _SOURCE_FAILURE_THRESHOLD = 4
-_MIN_VALID_FILE_SIZE = 10 * 1024
 _AA_COUNTDOWN_MAX_SECONDS = 300
+
 
 # --- Distant-path language detection ---
 
@@ -252,8 +219,6 @@ _LANGUAGE_CODE_TOKEN_PATTERN = re.compile(
     r"(?:^|[\s_./\\\-\[(])([A-Za-z]{2,3})(?=$|[\s_./\\\-)\]])"
 )
 _LANGUAGE_NAME_TOKEN_PATTERN = re.compile(r"[a-z]{4,}(?:-[a-z0-9]+)?")
-_LANGUAGE_ALIAS_TO_CODE: dict[str, str] | None = None
-_LANGUAGE_ALIAS_LOCK = threading.Lock()
 _LANGUAGE_PLACEHOLDERS = frozenset({"", "-", "--", "unknown", "unk", "n/a", "na"})
 # Short codes that appear in common words — require bracket/key context to accept
 _AMBIGUOUS_SHORT_LANGUAGE_CODES = frozenset({"de", "en", "it", "la", "no", "or", "is", "in"})
@@ -269,32 +234,9 @@ def _is_language_from_path_enabled() -> bool:
     return bool(config.get("DIRECT_DOWNLOAD_LANGUAGE_FROM_PATH", False))
 
 
-def _normalize_language_token(value: str) -> str:
-    normalized = value.strip().lower()
-    for dash in ("‑", "–", "—", "−"):
-        normalized = normalized.replace(dash, "-")
-    return normalized
-
-
 def _fold_text(value: str) -> str:
     normalized = unicodedata.normalize("NFKD", value)
     return "".join(c for c in normalized if not unicodedata.combining(c)).lower()
-
-
-def _language_alias_to_code() -> dict[str, str]:
-    """Alias to code map, delegating to the shared language data."""
-    global _LANGUAGE_ALIAS_TO_CODE
-    cached = _LANGUAGE_ALIAS_TO_CODE
-    if cached is not None:
-        return cached
-
-    with _LANGUAGE_ALIAS_LOCK:
-        cached = _LANGUAGE_ALIAS_TO_CODE
-        if cached is not None:
-            return cached
-
-        _LANGUAGE_ALIAS_TO_CODE = language_alias_map()
-        return _LANGUAGE_ALIAS_TO_CODE
 
 
 def _extract_distant_path(row: Tag, *, enabled: bool) -> str | None:
@@ -342,7 +284,7 @@ def _detect_language_from_distant_path(path: str | None) -> str | None:
     if not path:
         return None
 
-    aliases = _language_alias_to_code()
+    aliases = language_alias_to_code()
     if not aliases:
         return None
 
@@ -350,12 +292,12 @@ def _detect_language_from_distant_path(path: str | None) -> str | None:
     strong_candidates: list[str] = []
 
     for code in _BRACKETED_LANGUAGE_CODE_PATTERN.findall(path):
-        normalized = _normalize_language_token(code)
+        normalized = normalize_language_token(code)
         if normalized in aliases:
             strong_candidates.append(aliases[normalized])
 
     for code in _KEYED_LANGUAGE_CODE_PATTERN.findall(path):
-        normalized = _normalize_language_token(code)
+        normalized = normalize_language_token(code)
         if normalized in aliases:
             strong_candidates.append(aliases[normalized])
 
@@ -364,7 +306,7 @@ def _detect_language_from_distant_path(path: str | None) -> str | None:
         return non_ambiguous[0]
 
     for token in _LANGUAGE_NAME_TOKEN_PATTERN.findall(folded_path):
-        normalized = _normalize_language_token(token)
+        normalized = normalize_language_token(token)
         if normalized in aliases:
             candidate = aliases[normalized]
             if candidate not in _AMBIGUOUS_SHORT_LANGUAGE_CODES:
@@ -374,7 +316,7 @@ def _detect_language_from_distant_path(path: str | None) -> str | None:
         return strong_candidates[0]
 
     for code in _LANGUAGE_CODE_TOKEN_PATTERN.findall(path):
-        normalized = _normalize_language_token(code)
+        normalized = normalize_language_token(code)
         if normalized in _AMBIGUOUS_SHORT_LANGUAGE_CODES:
             continue
         if normalized in aliases:
@@ -386,38 +328,7 @@ def _detect_language_from_distant_path(path: str | None) -> str | None:
 def _is_missing_or_placeholder_language(language: str | None) -> bool:
     if language is None:
         return True
-    return _normalize_language_token(language) in _LANGUAGE_PLACEHOLDERS
-
-
-def _normalize_requested_languages(languages: list[str] | None) -> set[str]:
-    if not languages:
-        return set()
-    aliases = _language_alias_to_code()
-    normalized: set[str] = set()
-    for value in languages:
-        token = _normalize_language_token(str(value))
-        if not token or token == "all":  # noqa: S105 - "all" is a language sentinel
-            continue
-        normalized.add(aliases.get(token, token))
-    return normalized
-
-
-def _book_matches_requested_languages(book_language: str | None, requested: set[str]) -> bool:
-    """Return True when a book's language matches the requested filter.
-
-    Books with unknown/missing language always pass — the server-side &lang= filter
-    already narrowed the result set, so dropping unlabelled rows hides valid results.
-    """
-    if not requested:
-        return True
-    if not book_language:
-        return True
-    aliases = _language_alias_to_code()
-    normalized_book = aliases.get(
-        _normalize_language_token(book_language),
-        _normalize_language_token(book_language),
-    )
-    return normalized_book in requested
+    return normalize_language_token(language) in _LANGUAGE_PLACEHOLDERS
 
 
 def _is_configured_zlib_link(url: str) -> bool:
@@ -516,7 +427,7 @@ def _is_source_enabled(source_id: str) -> bool:
     return False
 
 
-def _get_direct_download_unavailable_reason() -> str | None:
+def get_unavailable_reason() -> str | None:
     """Return a user-facing reason when Direct Download cannot be used."""
     from shelfmark.core import mirrors
 
@@ -534,23 +445,14 @@ def _get_direct_download_unavailable_reason() -> str | None:
     return None
 
 
-def _ensure_direct_download_available() -> None:
+def ensure_available() -> None:
     """Raise a source-unavailable error when Direct Download is disabled or unconfigured."""
-    reason = _get_direct_download_unavailable_reason()
+    reason = get_unavailable_reason()
     if reason:
         raise SearchUnavailableError(reason)
 
 
-_SIZE_UNIT_PATTERN = re.compile(r"(kb|mb|gb|tb)", re.IGNORECASE)
-
-
-def _normalize_size(size_str: str) -> str:
-    """Normalize size string by uppercasing units (e.g., '5.2 mb' -> '5.2 MB')."""
-    return _SIZE_UNIT_PATTERN.sub(lambda m: m.group(1).upper(), size_str.strip())
-
-
-class SearchUnavailableError(SourceUnavailableError):
-    """Raised when Anna's Archive cannot be reached via any mirror/DNS."""
+SearchUnavailableError = DirectDownloadUnavailableError
 
 
 # Markers that prove a 200 really came from Anna's Archive, and markers that mean we
@@ -599,7 +501,7 @@ _search_page_cache: ContextVar[dict[str, tuple[str, Tag | None]] | None] = Conte
 
 
 @contextmanager
-def _search_page_reuse() -> Iterator[None]:
+def search_page_reuse() -> Iterator[None]:
     """Fetch each distinct AA search URL at most once per search.
 
     One search asks AA for the same URL more than once. The language-filter retry in
@@ -717,7 +619,7 @@ def _fetch_search_table_uncached(
             allow_bypasser_fallback=True,
             include_response_url=True,
         )
-        html = _html_response_text(response)
+        html = html_response_text(response)
         # Checked on the body, not on `response`: with include_response_url the give-up
         # shape is the tuple ("", url), and a tuple is truthy.
         if not html:
@@ -808,7 +710,7 @@ def search_books(query: str, filters: SearchFilters) -> list[BrowseRecord]:
     filters_query = ""
 
     path_language_enabled = _is_language_from_path_enabled()
-    requested_langs = _normalize_requested_languages(filters.lang)
+    requested_langs = normalize_requested_languages(filters.lang)
 
     # When path-language inference is on and a language is requested, skip the
     # server-side &lang= filter: lgli files often have no AA language metadata
@@ -826,7 +728,7 @@ def search_books(query: str, filters: SearchFilters) -> list[BrowseRecord]:
         for value in filters.content:
             filters_query += f"&content={quote(value)}"
 
-    formats_to_use = filters.format or _get_supported_formats()
+    formats_to_use = filters.format or get_supported_formats()
 
     index = 1
     for filter_type, filter_values in vars(filters).items():
@@ -860,16 +762,18 @@ def search_books(query: str, filters: SearchFilters) -> list[BrowseRecord]:
         msg = f"Expected results table tag, got {type(tbody).__name__}"
         raise TypeError(msg)
 
-    books = []
-    for line_tr in tbody.find_all("tr"):
-        book = _parse_search_result_row(line_tr)
-        if book:
-            books.append(book)
+    books = parse_search_page(
+        tbody,
+        filters,
+        provider_id="annas_archive",
+        item_selector="tr",
+        extract_item=_extract_aa_search_result,
+    )
 
     if path_language_enabled and requested_langs:
         books = [b for b in books if _book_matches_requested_languages(b.language, requested_langs)]
 
-    supported_formats = _get_supported_formats()
+    supported_formats = get_supported_formats()
 
     books.sort(
         key=lambda x: (
@@ -905,13 +809,13 @@ def get_book_info(book_id: str, *, fetch_download_count: bool = True) -> BrowseR
         )
         raise SearchUnavailableError(f"Unable to reach download source. {detail}")
 
-    soup = BeautifulSoup(_html_response_text(html), "html.parser")
+    soup = BeautifulSoup(html_response_text(html), "html.parser")
 
     return _parse_book_info_page(soup, book_id, fetch_download_count=fetch_download_count)
 
 
-def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
-    """Parse a single search result row into a browse record."""
+def _extract_aa_search_result(row: Tag) -> ParsedSearchResult | None:
+    """Extract Anna's Archive table fields for the shared parser."""
     try:
         if row.text.strip().lower().startswith("your ad here"):
             return None
@@ -921,7 +825,7 @@ def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
         if len(cells) < 11 or not anchors:
             return None
 
-        record_id = (_get_attr(anchors[0], "href") or "").split("/")[-1]
+        record_id = (get_attr(anchors[0], "href") or "").split("/")[-1]
         if not record_id:
             return None
 
@@ -929,7 +833,7 @@ def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
         distant_path = _extract_distant_path(row, enabled=path_language_enabled)
 
         preview_img = cells[0].find("img")
-        preview = _get_attr(preview_img, "src") if isinstance(preview_img, Tag) else None
+        preview = get_attr(preview_img, "src") if isinstance(preview_img, Tag) else None
 
         title_span = cells[1].find("span")
         if isinstance(title_span, Tag):
@@ -963,23 +867,35 @@ def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
             detected = _detect_language_from_distant_path(distant_path)
             language = detected or "unknown"
 
-        return BrowseRecord(
-            id=record_id,
+        return ParsedSearchResult(
+            key=record_id,
+            record_id=record_id,
             title=title,
-            source="direct_download",
+            formats=(file_format.lower(),),
             preview=preview,
             author=author,
             publisher=publisher,
             year=year,
             language=language,
             content=content.lower() if content else None,
-            format=file_format.lower() if file_format else None,
             size=size,
             download_path=distant_path,
+            source_url=f"{network.get_aa_base_url()}/md5/{record_id}",
         )
     except (AttributeError, IndexError, KeyError, TypeError) as e:
         logger.error_trace(f"Error parsing search result row: {e}")
         return None
+
+
+def _parse_search_result_row(row: Tag) -> BrowseRecord | None:
+    """Compatibility wrapper for parsing one Anna's Archive result row."""
+    records = parse_search_items(
+        [row],
+        None,
+        provider_id="annas_archive",
+        extract_item=_extract_aa_search_result,
+    )
+    return records[0] if records else None
 
 
 def _parse_book_info_page(
@@ -999,7 +915,7 @@ def _parse_book_info_page(
 
     node = data.select_one("div:nth-of-type(1) > img")
     if isinstance(node, Tag):
-        preview = _get_attr(node, "src") or ""
+        preview = get_attr(node, "src") or ""
 
     main_inner = next(
         (tag for tag in soup.find_all("div", {"class": "main-inner"}) if isinstance(tag, Tag)),
@@ -1023,7 +939,7 @@ def _parse_book_info_page(
     for anchor in soup.find_all("a"):
         try:
             text = anchor.text.strip().lower()
-            href = _get_attr(anchor, "href")
+            href = get_attr(anchor, "href")
             if not href:
                 continue
 
@@ -1075,7 +991,7 @@ def _parse_book_info_page(
     file_format = ""
     size = ""
     content = ""
-    supported_formats = _get_supported_formats()
+    supported_formats = get_supported_formats()
 
     for _details in all_details:
         _details = _details.split(" · ")
@@ -1084,7 +1000,7 @@ def _parse_book_info_page(
             if file_format == "" and stripped_lower in supported_formats:
                 file_format = f.strip().lower()
             if size == "" and any(u in f.strip().lower() for u in ("mb", "kb", "gb")):
-                size = _normalize_size(f)
+                size = normalize_size(f)
             if content == "":
                 for ct in CONTENT_TYPES:
                     if ct in f.strip().lower():
@@ -1096,7 +1012,7 @@ def _parse_book_info_page(
                 if file_format == "" and stripped and " " not in stripped:
                     file_format = stripped
                 if size == "" and "." in stripped:
-                    size = _normalize_size(f)
+                    size = normalize_size(f)
 
     book_title = (_find_in_divs(divs, "🔍") or [""])[0].strip("🔍").strip()
 
@@ -1134,7 +1050,7 @@ def _parse_book_info_page(
                 summary_url, selector=network.AAMirrorSelector(), allow_bypasser_fallback=False
             )
             if summary_response:
-                summary_data = json.loads(_html_response_text(summary_response))
+                summary_data = json.loads(html_response_text(summary_response))
                 if "downloads_total" in summary_data:
                     info["Downloads"] = [str(summary_data["downloads_total"])]
         except (
@@ -1456,11 +1372,11 @@ def _get_download_urls_from_welib(
         logger.warning("Welib page empty for %s", book_id)
         return []
 
-    soup = BeautifulSoup(_html_response_text(html), "html.parser")
+    soup = BeautifulSoup(html_response_text(html), "html.parser")
     links = [
         downloader.get_absolute_url(url, href)
         for a in soup.find_all("a", href=True)
-        if (href := _get_attr(a, "href")) and "/slow_download/" in href
+        if (href := get_attr(a, "href")) and "/slow_download/" in href
     ]
     return list(dict.fromkeys(links))  # Dedupe while preserving order
 
@@ -1524,7 +1440,7 @@ def _extract_libgen_download_url(link: str, cancel_flag: Event | None = None) ->
         return download_url
 
 
-def _download_book(
+def download_book(
     book_info: BrowseRecord,
     book_path: Path,
     progress_callback: Callable[[float], None] | None = None,
@@ -1650,7 +1566,7 @@ def _get_download_url(
         page = downloader.html_get_page(
             link, selector=sel, cancel_flag=cancel_flag, status_callback=status_callback
         )
-        page_data = json.loads(_html_response_text(page))
+        page_data = json.loads(html_response_text(page))
         download_url = page_data.get("download_url", "")
         return (
             downloader.get_absolute_url(link, download_url) if isinstance(download_url, str) else ""
@@ -1665,7 +1581,7 @@ def _get_download_url(
     if not html:
         return ""
 
-    soup = BeautifulSoup(_html_response_text(html), "html.parser")
+    soup = BeautifulSoup(html_response_text(html), "html.parser")
     url = ""
 
     # Z-Library
@@ -1678,9 +1594,9 @@ def _get_download_url(
                 link, selector=sel, cancel_flag=cancel_flag, status_callback=status_callback
             )
             if html:
-                soup = BeautifulSoup(_html_response_text(html), "html.parser")
+                soup = BeautifulSoup(html_response_text(html), "html.parser")
                 dl = soup.find("a", href=True, class_="addDownloadedBook")
-        url = (_get_attr(dl, "href") or "") if isinstance(dl, Tag) else ""
+        url = (get_attr(dl, "href") or "") if isinstance(dl, Tag) else ""
 
     # AA slow download / partner servers
     elif "/slow_download/" in link:
@@ -1693,7 +1609,7 @@ def _get_download_url(
             soup, "Download"
         )
         if get_btn:
-            url = _get_attr(get_btn, "href") or ""
+            url = get_attr(get_btn, "href") or ""
         else:
             logger.warning("Unknown source type, couldn't find download link: %s", link)
             url = ""
@@ -1727,11 +1643,11 @@ def _extract_slow_download_url(
         soup, "Download now", contains=True
     )
     if dl_link:
-        return _get_attr(dl_link, "href") or ""
+        return get_attr(dl_link, "href") or ""
 
     for a_tag in soup.find_all("a", href=True):
         if a_tag.has_attr("download"):
-            href = _get_attr(a_tag, "href")
+            href = get_attr(a_tag, "href")
             if not href:
                 continue
             if href.startswith("http") and "/slow_download/" not in href:
@@ -1762,7 +1678,7 @@ def _extract_slow_download_url(
         parent = copy_text.parent
         next_link = parent.find_next("a", href=True)
         if isinstance(next_link, Tag):
-            next_href = _get_attr(next_link, "href")
+            next_href = get_attr(next_link, "href")
             if next_href:
                 return next_href
         code_elem = parent.find_next("code")
@@ -1825,7 +1741,7 @@ def _extract_slow_download_url(
         )
         if not html:
             return ""
-        new_soup = BeautifulSoup(_html_response_text(html), "html.parser")
+        new_soup = BeautifulSoup(html_response_text(html), "html.parser")
         return _extract_slow_download_url(
             new_soup,
             link,
@@ -1915,119 +1831,48 @@ def _parse_countdown_seconds_from_element(element: Tag) -> int | None:
     return None
 
 
-def _browse_record_to_release(record: BrowseRecord) -> Release:
-    """Convert a browse record to a Release object.
+class AnnasArchiveProvider:
+    """Anna's Archive provider, including its specialized MD5 mirror cascade."""
 
-    This bridges the direct source's browse data to the generic release model.
-    """
-    return Release(
-        source=record.source,
-        source_id=record.id,
-        title=record.title,
-        format=record.format,
-        language=record.language,  # Top-level language for filtering
-        size=record.size,
-        download_url=record.download_urls[0] if record.download_urls else None,
-        info_url=f"{network.get_aa_base_url()}/md5/{record.id}",
-        protocol=ReleaseProtocol.HTTP,
-        indexer="Direct Download",
-        content_type=record.content,  # Preserve content type from source
-        extra={
-            "author": record.author,
-            "publisher": record.publisher,
-            "year": record.year,
-            "language": record.language,
-            "preview": record.preview,
-            "description": record.description,
-            "download_urls": record.download_urls,
-            "info": record.info,
-        },
-    )
-
-
-@register_source("direct_download")
-class DirectDownloadSource(ReleaseSource):
-    """Direct download source - searches web sources for books.
-
-    This wraps the search_books() functionality to provide releases
-    via the plugin interface.
-    """
-
-    name = "direct_download"
-    display_name = "Direct Download"
-    supported_content_types: ClassVar[list[str]] = ["ebook"]  # Direct downloads only support ebooks
+    id = "annas_archive"
+    display_name = "Anna's Archive"
 
     def __init__(self) -> None:
-        """Initialize per-instance search state for direct downloads."""
-        # Tracks which search method was used in the last search() call
-        # "isbn" = ISBN search returned results, "title_author" = title+author was used
-        self._last_search_type: str = "title_author"
+        self._last_search_type = "title_author"
 
     @property
     def last_search_type(self) -> str:
-        """Returns the search type used in the last search() call."""
         return self._last_search_type
 
-    def get_column_config(self) -> ReleaseColumnConfig:
-        """Column configuration for Direct Download source.
+    def is_enabled(self) -> bool:
+        from shelfmark.core import mirrors
 
-        Shows language, format, and size badges for each release.
-        Language is hidden on mobile; format and size are shown.
-        """
-        return ReleaseColumnConfig(
-            columns=[
-                ColumnSchema(
-                    key="extra.language",
-                    label="Language",
-                    render_type=ColumnRenderType.BADGE,
-                    align=ColumnAlign.CENTER,
-                    width="60px",
-                    hide_mobile=False,  # Language shown on mobile
-                    color_hint=ColumnColorHint(type="map", value="language"),
-                    uppercase=True,
-                ),
-                ColumnSchema(
-                    key="format",
-                    label="Format",
-                    render_type=ColumnRenderType.BADGE,
-                    align=ColumnAlign.CENTER,
-                    width="80px",
-                    hide_mobile=False,  # Format shown on mobile
-                    color_hint=ColumnColorHint(type="map", value="format"),
-                    uppercase=True,
-                ),
-                ColumnSchema(
-                    key="size",
-                    label="Size",
-                    render_type=ColumnRenderType.SIZE,
-                    align=ColumnAlign.CENTER,
-                    width="80px",
-                    hide_mobile=False,  # Size shown on mobile
-                ),
-            ],
-            grid_template="minmax(0,2fr) 60px 80px 80px",
-            supported_filters=["format", "language"],  # AA has reliable language metadata
+        return mirrors.has_aa_mirror_configuration()
+
+    def handles(self, url: str) -> bool:
+        from shelfmark.core import mirrors
+
+        hostname = (urlparse(url).hostname or "").lower().rstrip(".")
+        if not hostname:
+            return False
+        return any(
+            hostname == (urlparse(base_url).hostname or "").lower().rstrip(".")
+            for base_url in mirrors.get_aa_mirrors()
         )
 
-    def get_record(
-        self,
-        record_id: str,
-        *,
-        fetch_download_count: bool = True,
-    ) -> BrowseRecord | None:
-        """Resolve a direct-download record for direct-mode info/download flows."""
-        _ensure_direct_download_available()
+    def get_record(self, record_id: str, *, fetch_download_count: bool = True) -> BrowseRecord:
+        ensure_available()
         return get_book_info(record_id, fetch_download_count=fetch_download_count)
 
-    def search_results_are_releases(self) -> bool:
-        """Direct search results already represent concrete downloadable releases."""
-        return True
-
-    def get_destination_override(self, task: DownloadTask) -> Path | None:
-        """Apply Anna's Archive content-type routing when configured."""
-        if check_audiobook(task.content_type):
-            return None
-        return get_aa_content_type_dir(task.content_type)
+    def download(
+        self,
+        book_info: BrowseRecord,
+        book_path: Path,
+        progress_callback: Callable[[float], None] | None,
+        cancel_flag: Event | None,
+        status_callback: Callable[[str, str | None], None] | None,
+    ) -> str | None:
+        return download_book(book_info, book_path, progress_callback, cancel_flag, status_callback)
 
     def _search_books_with_language_fallback(
         self,
@@ -2055,14 +1900,15 @@ class DirectDownloadSource(ReleaseSource):
         *,
         expand_search: bool = False,
         content_type: str = "ebook",
-    ) -> list[Release]:
-        """Search for releases using the book's metadata.
-
-        The whole fan-out runs under one page cache, so a URL built twice by different
-        passes is fetched once. See `_search_page_reuse`.
-        """
-        with _search_page_reuse():
-            return self._search(book, plan, expand_search=expand_search, content_type=content_type)
+    ) -> list[BrowseRecord]:
+        """Search for releases using the book's metadata with request-local page reuse."""
+        with search_page_reuse():
+            return self._search(
+                book,
+                plan,
+                expand_search=expand_search,
+                content_type=content_type,
+            )
 
     def _search(
         self,
@@ -2071,8 +1917,8 @@ class DirectDownloadSource(ReleaseSource):
         *,
         expand_search: bool = False,
         content_type: str = "ebook",
-    ) -> list[Release]:
-        """Search for releases using the book's metadata.
+    ) -> list[BrowseRecord]:
+        """Run Anna's Archive's ISBN-first and localized-title search strategy.
 
         Priority: ISBN search first (most precise), then title+author fallback.
         For non-English languages, uses localized titles from book.titles_by_language.
@@ -2085,7 +1931,7 @@ class DirectDownloadSource(ReleaseSource):
             content_type: Ignored - Direct download uses format filtering instead
 
         """
-        _ensure_direct_download_available()
+        ensure_available()
         lang_filter = plan.languages
 
         # Reset search type tracking
@@ -2102,7 +1948,7 @@ class DirectDownloadSource(ReleaseSource):
                 query, filters, search_label="manual"
             )
             self._last_search_type = "manual" if query else "title_author"
-            return [_browse_record_to_release(record) for record in results]
+            return results
 
         # ISBN search first (unless expand_search requested)
         if plan.manual_query:
@@ -2119,7 +1965,7 @@ class DirectDownloadSource(ReleaseSource):
                     if results:
                         logger.info("Found %s releases via ISBN", len(results))
                         self._last_search_type = "isbn"
-                        return [_browse_record_to_release(record) for record in results]
+                        return results
                     logger.debug("No ISBN results, falling back to title+author")
                 except SearchUnavailableError:
                     raise
@@ -2184,155 +2030,4 @@ class DirectDownloadSource(ReleaseSource):
                 except Exception:
                     logger.exception("Search error")
 
-        return [_browse_record_to_release(record) for record in all_results]
-
-    def is_available(self) -> bool:
-        """Check if Direct Download has been explicitly enabled and configured."""
-        return _get_direct_download_unavailable_reason() is None
-
-
-@register_handler("direct_download")
-class DirectDownloadHandler(DownloadHandler):
-    """Handler for direct HTTP downloads from Anna's Archive, Libgen, etc.
-
-    Receives a DownloadTask with task_id (AA MD5 hash) and cascades through
-    sources in priority order. The AA page is only fetched if AA slow sources
-    are enabled in the user's source priority configuration.
-    """
-
-    def download(
-        self,
-        task: DownloadTask,
-        cancel_flag: Event,
-        progress_callback: Callable[[float], None],
-        status_callback: Callable[[str, str | None], None],
-    ) -> str | None:
-        """Execute a direct HTTP download.
-
-        Uses task.task_id (AA MD5 hash) to cascade through sources in priority
-        order. The AA page is only fetched if AA slow sources are enabled.
-
-        Args:
-            task: Download task with task_id (AA MD5 hash)
-            cancel_flag: Event to check for cancellation
-            progress_callback: Called with progress percentage (0-100)
-            status_callback: Called with (status, message) for status updates
-
-        Returns:
-            Path to downloaded file if successful, None otherwise
-
-        """
-        try:
-            # Check for cancellation before starting
-            if cancel_flag.is_set():
-                logger.info("Download cancelled before starting: %s", task.task_id)
-                status_callback("cancelled", "Cancelled")
-                return None
-
-            # Create browse record from task data - NO AA page fetch here
-            # AA page is fetched lazily by _fetch_aa_page_urls only when
-            # we actually reach an AA slow source in the priority order
-            book_info = BrowseRecord(
-                id=task.task_id,
-                title=task.title,
-                source="direct_download",
-                author=task.author,
-                year=task.year,
-                format=task.format,
-                size=task.size,
-                preview=task.preview,
-            )
-
-            return self._execute_download(
-                book_info, cancel_flag, progress_callback, status_callback
-            )
-
-        except Exception as e:
-            if cancel_flag.is_set():
-                logger.info("Download cancelled during error handling: %s", task.task_id)
-                status_callback("cancelled", "Cancelled")
-            else:
-                logger.exception("Error downloading book")
-                status_callback("error", str(e))
-            return None
-
-    def _execute_download(
-        self,
-        book_info: BrowseRecord,
-        cancel_flag: Event,
-        progress_callback: Callable[[float], None],
-        status_callback: Callable[[str, str | None], None],
-    ) -> str | None:
-        """Execute the direct-download flow with a fetched browse record.
-
-        This contains the core download logic: cascade through sources,
-        handle bypass, move to final location.
-        """
-        try:
-            logger.debug("Starting download: %s", book_info.title)
-
-            # Prepare paths - use descriptive staging filename, orchestrator will rename
-            # based on FILE_ORGANIZATION setting
-            file_org = config.get("FILE_ORGANIZATION", "rename")
-            if file_org == "none":
-                book_name = f"{book_info.id}.{book_info.format or 'bin'}"
-            else:
-                book_name = build_filename(
-                    book_info.title,
-                    book_info.author,
-                    book_info.year,
-                    book_info.format,
-                )
-            book_path = TMP_DIR / book_name
-
-            # Check cancellation before download
-            if cancel_flag.is_set():
-                logger.info("Download cancelled before download call: %s", book_info.id)
-                status_callback("cancelled", "Cancelled")
-                return None
-
-            # Execute download via _download_book (handles cascade and bypass)
-            status_callback("resolving", "Finding download source")
-            success_url = _download_book(
-                book_info, book_path, progress_callback, cancel_flag, status_callback
-            )
-
-            # Check for cancellation after download
-            if cancel_flag.is_set():
-                logger.info("Download cancelled during download: %s", book_info.id)
-                if book_path.exists():
-                    book_path.unlink()
-                status_callback("cancelled", "Cancelled")
-                return None
-
-            if not success_url:
-                if network.dns_interference_detected():
-                    status_callback(
-                        "error",
-                        "All sources failed - your network/ISP appears to be blocking "
-                        "Anna's Archive. Enable DNS-over-HTTPS in settings.",
-                    )
-                else:
-                    status_callback("error", "All download sources failed")
-                return None
-
-            # Return temp path - orchestrator handles post-processing (archive extraction, ingest)
-            return str(book_path)
-
-        except Exception:
-            if cancel_flag.is_set():
-                logger.info("Download cancelled during error handling: %s", book_info.id)
-                status_callback("cancelled", "Cancelled")
-            else:
-                logger.exception("Error downloading book")
-            return None
-
-    def cancel(self, task_id: str) -> bool:
-        """Cancel an in-progress download.
-
-        Cancellation is handled via the cancel_flag passed to download().
-        This method exists for the interface but actual cancellation
-        happens through the Event flag mechanism.
-        """
-        # Cancellation is handled by the orchestrator via cancel_flag
-        return False
+        return all_results

--- a/shelfmark/release_sources/direct_download/annas_archive.py
+++ b/shelfmark/release_sources/direct_download/annas_archive.py
@@ -407,7 +407,7 @@ def _get_source_priority() -> list[SourcePriorityEntry]:
 
     slow_sources = _parse_source_priority_entries(
         config.get("SOURCE_PRIORITY"),
-        excluded_ids={"aa-fast", "libgen"},
+        excluded_ids={"aa-fast", "libgen", "oceanofpdf"},
     )
     for source in slow_sources:
         if not mirrors.has_download_source_mirror_configuration(source["id"]):

--- a/shelfmark/release_sources/direct_download/common.py
+++ b/shelfmark/release_sources/direct_download/common.py
@@ -1,0 +1,264 @@
+"""Shared contracts and result normalization for Direct Download websites."""
+
+import hashlib
+import re
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from bs4 import BeautifulSoup, Tag
+
+from shelfmark.core.config import config
+from shelfmark.core.languages import language_alias_map
+from shelfmark.release_sources import BrowseRecord, SourceUnavailableError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+    from pathlib import Path
+    from threading import Event
+
+    from shelfmark.core.models import SearchFilters
+    from shelfmark.core.search_plan import ReleaseSearchPlan
+    from shelfmark.metadata_providers import BookMetadata
+
+_LANGUAGE_ALIAS_TO_CODE: dict[str, str] | None = None
+_LANGUAGE_ALIAS_LOCK = threading.Lock()
+_SIZE_UNIT_PATTERN = re.compile(r"(kb|mb|gb|tb)", re.IGNORECASE)
+MIN_VALID_FILE_SIZE = 10 * 1024
+
+
+class DirectDownloadUnavailableError(SourceUnavailableError):
+    """Raised when the composite Direct Download source cannot be reached."""
+
+
+def coerce_str_list(value: object) -> list[str]:
+    """Return only string items from a config value."""
+    if not isinstance(value, list | tuple):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def get_supported_formats() -> list[str]:
+    """Return configured supported formats as a clean string list."""
+    return coerce_str_list(config.SUPPORTED_FORMATS)
+
+
+def html_response_text(response: str | tuple[str, str]) -> str:
+    """Extract the HTML body from downloader responses."""
+    if isinstance(response, tuple):
+        return response[0]
+    return response
+
+
+def attr_to_str(value: object) -> str | None:
+    """Convert a BeautifulSoup attribute value to a plain string."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, str):
+                return item
+    return None
+
+
+def get_attr(tag: Tag, attr: str) -> str | None:
+    """Safely fetch a tag attribute as a string."""
+    return attr_to_str(tag.get(attr))
+
+
+@dataclass(frozen=True)
+class ParsedSearchResult:
+    """Provider-neutral fields extracted from one search-result element."""
+
+    key: str
+    title: str
+    formats: tuple[str, ...]
+    record_id: str | None = None
+    author: str | None = None
+    publisher: str | None = None
+    year: str | None = None
+    language: str | None = None
+    content: str | None = None
+    size: str | None = None
+    preview: str | None = None
+    source_url: str | None = None
+    download_path: str | None = None
+
+
+class DirectDownloadProvider(Protocol):
+    """Provider lifecycle used by the composite Direct Download source."""
+
+    id: str
+    display_name: str
+
+    def is_enabled(self) -> bool: ...
+
+    def handles(self, url: str) -> bool: ...
+
+    def search(
+        self,
+        book: BookMetadata,
+        plan: ReleaseSearchPlan,
+        *,
+        expand_search: bool = False,
+        content_type: str = "ebook",
+    ) -> list[BrowseRecord]: ...
+
+    def download(
+        self,
+        book_info: BrowseRecord,
+        book_path: Path,
+        progress_callback: Callable[[float], None] | None,
+        cancel_flag: Event | None,
+        status_callback: Callable[[str, str | None], None] | None,
+    ) -> str | None: ...
+
+
+@runtime_checkable
+class RecordLookupProvider(Protocol):
+    """Optional capability for providers that can reopen source-native records."""
+
+    def get_record(
+        self, record_id: str, *, fetch_download_count: bool = True
+    ) -> BrowseRecord | None: ...
+
+
+def normalize_language_token(value: str) -> str:
+    normalized = value.strip().lower()
+    for dash in ("‑", "–", "—", "−"):
+        normalized = normalized.replace(dash, "-")
+    return normalized
+
+
+def language_alias_to_code() -> dict[str, str]:
+    """Alias to code map, delegating to the shared language data."""
+    global _LANGUAGE_ALIAS_TO_CODE
+    cached = _LANGUAGE_ALIAS_TO_CODE
+    if cached is not None:
+        return cached
+
+    with _LANGUAGE_ALIAS_LOCK:
+        cached = _LANGUAGE_ALIAS_TO_CODE
+        if cached is not None:
+            return cached
+
+        _LANGUAGE_ALIAS_TO_CODE = language_alias_map()
+        return _LANGUAGE_ALIAS_TO_CODE
+
+
+def normalize_requested_languages(languages: list[str] | None) -> set[str]:
+    if not languages:
+        return set()
+    aliases = language_alias_to_code()
+    normalized: set[str] = set()
+    for value in languages:
+        token = normalize_language_token(str(value))
+        if not token or token == "all":  # noqa: S105 - "all" is a language sentinel
+            continue
+        normalized.add(aliases.get(token, token))
+    return normalized
+
+
+def book_matches_requested_languages(book_language: str | None, requested: set[str]) -> bool:
+    """Return True when a book's language matches the requested filter.
+
+    Books with unknown/missing language always pass — the server-side &lang= filter
+    already narrowed the result set, so dropping unlabelled rows hides valid results.
+    """
+    if not requested:
+        return True
+    if not book_language:
+        return True
+    aliases = language_alias_to_code()
+    normalized_book = aliases.get(
+        normalize_language_token(book_language),
+        normalize_language_token(book_language),
+    )
+    return normalized_book in requested
+
+
+def normalize_size(size_str: str) -> str:
+    """Normalize size string by uppercasing units (e.g., '5.2 mb' -> '5.2 MB')."""
+    return _SIZE_UNIT_PATTERN.sub(lambda m: m.group(1).upper(), size_str.strip())
+
+
+def parse_search_items(
+    items: Iterable[Tag],
+    filters: SearchFilters | None,
+    *,
+    provider_id: str,
+    extract_item: Callable[[Tag], ParsedSearchResult | None],
+) -> list[BrowseRecord]:
+    """Normalize provider-specific HTML elements into Direct Download records.
+
+    Providers only describe how fields are extracted from their DOM. Language and
+    format filtering, stable IDs, and BrowseRecord construction stay shared.
+    """
+    requested_languages = normalize_requested_languages(filters.lang) if filters else set()
+    requested_formats = (
+        {value.casefold() for value in (filters.format or get_supported_formats())}
+        if filters
+        else set()
+    )
+    records: list[BrowseRecord] = []
+
+    for item in items:
+        parsed = extract_item(item)
+        if parsed is None:
+            continue
+
+        normalized_language = normalize_language_token(parsed.language) if parsed.language else ""
+        language = language_alias_to_code().get(normalized_language, normalized_language) or None
+        if not book_matches_requested_languages(language, requested_languages):
+            continue
+
+        formats = parsed.formats or ("",)
+        for book_format in formats:
+            normalized_format = book_format.casefold()
+            if (
+                normalized_format
+                and requested_formats
+                and normalized_format not in requested_formats
+            ):
+                continue
+            record_id = parsed.record_id
+            if not record_id or len(formats) > 1:
+                source_key = f"{parsed.key}#{normalized_format}"
+                digest = hashlib.blake2b(source_key.encode(), digest_size=16).hexdigest()
+                record_id = f"{provider_id}:{digest}"
+            records.append(
+                BrowseRecord(
+                    id=record_id,
+                    title=parsed.title,
+                    source="direct_download",
+                    author=parsed.author,
+                    publisher=parsed.publisher,
+                    year=parsed.year,
+                    language=language,
+                    format=normalized_format or None,
+                    size=parsed.size,
+                    preview=parsed.preview,
+                    content=parsed.content,
+                    source_url=parsed.source_url,
+                    download_path=parsed.download_path,
+                )
+            )
+    return records
+
+
+def parse_search_page(
+    page: str | BeautifulSoup | Tag,
+    filters: SearchFilters | None,
+    *,
+    provider_id: str,
+    item_selector: str,
+    extract_item: Callable[[Tag], ParsedSearchResult | None],
+) -> list[BrowseRecord]:
+    """Parse a result page using provider-specific selectors and extraction."""
+    root = BeautifulSoup(page, "html.parser") if isinstance(page, str) else page
+    return parse_search_items(
+        (item for item in root.select(item_selector) if isinstance(item, Tag)),
+        filters,
+        provider_id=provider_id,
+        extract_item=extract_item,
+    )

--- a/shelfmark/release_sources/direct_download/handler.py
+++ b/shelfmark/release_sources/direct_download/handler.py
@@ -1,0 +1,177 @@
+"""Direct Download routing, staging, and cancellation."""
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from shelfmark.config.env import TMP_DIR
+from shelfmark.core.config import config
+from shelfmark.core.logger import setup_logger
+from shelfmark.core.models import DownloadTask, build_filename
+from shelfmark.download import network
+from shelfmark.release_sources import (
+    BrowseRecord,
+    DownloadHandler,
+    register_handler,
+)
+from shelfmark.release_sources.direct_download import registry
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+    from threading import Event
+
+
+logger = setup_logger(__name__)
+
+
+def _download_book(
+    book_info: BrowseRecord,
+    book_path: Path,
+    progress_callback: Callable[[float], None] | None = None,
+    cancel_flag: Event | None = None,
+    status_callback: Callable[[str, str | None], None] | None = None,
+) -> str | None:
+    """Route a website record or an Anna's Archive MD5 to its download flow."""
+    provider = registry.provider_for_record(book_info)
+    if provider is None:
+        msg = f"No Direct Download provider owns record {book_info.id!r}"
+        raise RuntimeError(msg)
+    return provider.download(book_info, book_path, progress_callback, cancel_flag, status_callback)
+
+
+@register_handler("direct_download")
+class DirectDownloadHandler(DownloadHandler):
+    """Route and stage downloads from registered Direct Download providers."""
+
+    def download(
+        self,
+        task: DownloadTask,
+        cancel_flag: Event,
+        progress_callback: Callable[[float], None],
+        status_callback: Callable[[str, str | None], None],
+    ) -> str | None:
+        """Execute a provider-owned direct HTTP download.
+
+        Args:
+            task: Download task with a provider-owned source ID
+            cancel_flag: Event to check for cancellation
+            progress_callback: Called with progress percentage (0-100)
+            status_callback: Called with (status, message) for status updates
+
+        Returns:
+            Path to downloaded file if successful, None otherwise
+
+        """
+        try:
+            # Check for cancellation before starting
+            if cancel_flag.is_set():
+                logger.info("Download cancelled before starting: %s", task.task_id)
+                status_callback("cancelled", "Cancelled")
+                return None
+
+            # Reconstruct the provider-owned record without resolving it again.
+            book_info = BrowseRecord(
+                id=task.task_id,
+                title=task.title,
+                source="direct_download",
+                author=task.author,
+                year=task.year,
+                format=task.format,
+                size=task.size,
+                preview=task.preview,
+                source_url=task.source_url,
+            )
+
+            return self._execute_download(
+                book_info, cancel_flag, progress_callback, status_callback
+            )
+
+        except Exception as e:
+            if cancel_flag.is_set():
+                logger.info("Download cancelled during error handling: %s", task.task_id)
+                status_callback("cancelled", "Cancelled")
+            else:
+                logger.exception("Error downloading book")
+                status_callback("error", str(e))
+            return None
+
+    def _execute_download(
+        self,
+        book_info: BrowseRecord,
+        cancel_flag: Event,
+        progress_callback: Callable[[float], None],
+        status_callback: Callable[[str, str | None], None],
+    ) -> str | None:
+        """Execute the direct-download flow with a fetched browse record.
+
+        This contains the core download logic: cascade through sources,
+        handle bypass, move to final location.
+        """
+        try:
+            logger.debug("Starting download: %s", book_info.title)
+
+            # Prepare paths - use descriptive staging filename, orchestrator will rename
+            # based on FILE_ORGANIZATION setting
+            file_org = config.get("FILE_ORGANIZATION", "rename")
+            if file_org == "none":
+                book_name = f"{book_info.id}.{book_info.format or 'bin'}"
+            else:
+                book_name = build_filename(
+                    book_info.title,
+                    book_info.author,
+                    book_info.year,
+                    book_info.format,
+                )
+            book_path = TMP_DIR / book_name
+
+            # Check cancellation before download
+            if cancel_flag.is_set():
+                logger.info("Download cancelled before download call: %s", book_info.id)
+                status_callback("cancelled", "Cancelled")
+                return None
+
+            # Execute download via _download_book (handles cascade and bypass)
+            status_callback("resolving", "Finding download source")
+            success_url = _download_book(
+                book_info, book_path, progress_callback, cancel_flag, status_callback
+            )
+
+            # Check for cancellation after download
+            if cancel_flag.is_set():
+                logger.info("Download cancelled during download: %s", book_info.id)
+                if book_path.exists():
+                    book_path.unlink()
+                status_callback("cancelled", "Cancelled")
+                return None
+
+            if not success_url:
+                if network.dns_interference_detected():
+                    status_callback(
+                        "error",
+                        "All sources failed - your network/ISP appears to be blocking "
+                        "Anna's Archive. Enable DNS-over-HTTPS in settings.",
+                    )
+                else:
+                    status_callback("error", "All download sources failed")
+                return None
+
+            # Return temp path - orchestrator handles post-processing (archive extraction, ingest)
+            return str(book_path)
+
+        except Exception:
+            if cancel_flag.is_set():
+                logger.info("Download cancelled during error handling: %s", book_info.id)
+                status_callback("cancelled", "Cancelled")
+            else:
+                logger.exception("Error downloading book")
+            return None
+
+    def cancel(self, task_id: str) -> bool:
+        """Cancel an in-progress download.
+
+        Cancellation is handled via the cancel_flag passed to download().
+        This method exists for the interface but actual cancellation
+        happens through the Event flag mechanism.
+        """
+        # Cancellation is handled by the orchestrator via cancel_flag
+        return False

--- a/shelfmark/release_sources/direct_download/oceanofpdf.py
+++ b/shelfmark/release_sources/direct_download/oceanofpdf.py
@@ -1,0 +1,385 @@
+"""OceanofPDF search cards and form-based downloads."""
+
+import re
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING, TypedDict
+from urllib.parse import quote_plus, urlparse
+
+import requests
+from bs4 import BeautifulSoup, Tag
+
+from shelfmark.core import mirrors
+from shelfmark.core.config import config
+from shelfmark.core.models import SearchFilters
+from shelfmark.download import http as downloader
+from shelfmark.download import network
+from shelfmark.release_sources.direct_download.common import (
+    MIN_VALID_FILE_SIZE,
+    ParsedSearchResult,
+    get_attr,
+    html_response_text,
+    normalize_size,
+    parse_search_page,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from io import BytesIO
+    from threading import Event
+
+    from shelfmark.core.search_plan import ReleaseSearchPlan
+    from shelfmark.metadata_providers import BookMetadata
+    from shelfmark.release_sources import BrowseRecord
+
+_FORMAT_PATTERN = re.compile(r"\b(pdf|epub|mobi|azw3)\b", re.IGNORECASE)
+_SIZE_PATTERN = re.compile(r"\b\d+(?:\.\d+)?\s*(?:KB|MB|GB|TB)\b", re.IGNORECASE)
+_AUTO_DOWNLOAD_PATTERN = re.compile(
+    r"location\s*\.\s*href\s*=\s*(['\"])(?P<url>.+?)\1",
+    re.IGNORECASE,
+)
+_MAX_SEARCH_PAGES = 5
+_MAX_SEARCH_RESULTS = 25
+
+
+class _DownloadForm(TypedDict):
+    action: str
+    fields: dict[str, str]
+    format: str
+    size: str | None
+
+
+def _handles_url(url: str) -> bool:
+    """Recognize HTTP URLs on configured OceanofPDF mirrors and their subdomains."""
+    parsed = urlparse(url)
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    if parsed.scheme not in {"http", "https"} or not hostname:
+        return False
+    for mirror_url in mirrors.get_oceanofpdf_mirrors():
+        mirror_host = (urlparse(mirror_url).hostname or "").lower().rstrip(".")
+        if mirror_host and (hostname == mirror_host or hostname.endswith(f".{mirror_host}")):
+            return True
+    return False
+
+
+def _metadata_value(container: Tag | None, label: str) -> str | None:
+    """Read a labelled value from an OceanofPDF result card."""
+    if container is None:
+        return None
+    expected = label.casefold().rstrip(":")
+    for strong in container.find_all("strong"):
+        if strong.get_text(" ", strip=True).casefold().rstrip(":") != expected:
+            continue
+        values: list[str] = []
+        for sibling in strong.next_siblings:
+            if isinstance(sibling, Tag) and sibling.name == "br":
+                break
+            text = sibling.get_text(" ", strip=True) if isinstance(sibling, Tag) else str(sibling)
+            if text.strip():
+                values.append(text.strip())
+        return " ".join(values).strip() or None
+    return None
+
+
+def _formats(text: str) -> list[str]:
+    return list(dict.fromkeys(match.casefold() for match in _FORMAT_PATTERN.findall(text)))
+
+
+def _extract_search_item(article: Tag) -> ParsedSearchResult | None:
+    """Extract OceanofPDF-specific fields; shared parsing handles the rest."""
+    title_link = article.select_one(".entry-title a[href]")
+    if not isinstance(title_link, Tag):
+        return None
+    detail_url = get_attr(title_link, "href")
+    if not detail_url or not _handles_url(detail_url):
+        return None
+
+    metadata = article.select_one(".postmetainfo")
+    metadata_tag = metadata if isinstance(metadata, Tag) else None
+    image = article.select_one(".entry-image[data-src]") or article.select_one(".entry-image[src]")
+    image_tag = image if isinstance(image, Tag) else None
+    format_text = " ".join(
+        [
+            get_attr(article, "aria-label") or "",
+            title_link.get_text(" ", strip=True),
+            (article.select_one(".entry-content") or article).get_text(" ", strip=True),
+        ]
+    )
+    return ParsedSearchResult(
+        key=detail_url,
+        title=title_link.get_text(" ", strip=True),
+        formats=tuple(_formats(format_text)),
+        author=_metadata_value(metadata_tag, "Author"),
+        language=_metadata_value(metadata_tag, "Language"),
+        preview=(
+            (get_attr(image_tag, "data-src") or get_attr(image_tag, "src")) if image_tag else None
+        ),
+        content="ebook",
+        source_url=detail_url,
+    )
+
+
+def parse_results(html: str, filters: SearchFilters) -> list[BrowseRecord]:
+    """Parse OceanofPDF cards through the shared search-result parser."""
+    return parse_search_page(
+        html,
+        filters,
+        provider_id="oceanofpdf",
+        item_selector="article.entry",
+        extract_item=_extract_search_item,
+    )
+
+
+def parse_download_forms(html: str, detail_url: str) -> list[_DownloadForm]:
+    """Extract OceanofPDF's format-specific POST download buttons."""
+    soup = BeautifulSoup(html, "html.parser")
+    forms: list[_DownloadForm] = []
+    for form in soup.select("form[action]"):
+        action = downloader.get_absolute_url(detail_url, get_attr(form, "action") or "")
+        method = (get_attr(form, "method") or "get").lower()
+        if method != "post" or not _handles_url(action):
+            continue
+        fields = {
+            name: value
+            for field in form.select("input[name]")
+            if (name := get_attr(field, "name")) and (value := get_attr(field, "value"))
+        }
+        filename = fields.get("filename", "")
+        book_format = Path(filename).suffix.lstrip(".").casefold()
+        if book_format not in _formats(filename):
+            continue
+        nearby_text = form.parent.get_text(" ", strip=True) if isinstance(form.parent, Tag) else ""
+        size_match = _SIZE_PATTERN.search(nearby_text)
+        forms.append(
+            {
+                "action": action,
+                "fields": fields,
+                "format": book_format,
+                "size": normalize_size(size_match.group(0)) if size_match else None,
+            }
+        )
+    return forms
+
+
+def _select_download_form(forms: list[_DownloadForm], book_format: str | None) -> _DownloadForm:
+    selected = (
+        next((form for form in forms if form["format"] == book_format.casefold()), None)
+        if book_format
+        else (forms[0] if forms else None)
+    )
+    if selected is None:
+        requested = f" for {book_format.upper()}" if book_format else ""
+        raise RuntimeError(f"No OceanofPDF download button was found{requested}")
+    return selected
+
+
+def _parse_handoff_form(html: str, response_url: str) -> tuple[str, dict[str, str]]:
+    """Extract the form OceanofPDF auto-submits from its resource page."""
+    soup = BeautifulSoup(html, "html.parser")
+    form = soup.select_one("form#my_form[action]")
+    if not isinstance(form, Tag) or (get_attr(form, "method") or "get").casefold() != "post":
+        raise RuntimeError("OceanofPDF returned no download handoff form")
+    action = downloader.get_absolute_url(response_url, get_attr(form, "action") or "")
+    fields = {
+        name: get_attr(field, "value") or ""
+        for field in form.select("input[name]")
+        if (name := get_attr(field, "name"))
+    }
+    if not action:
+        raise RuntimeError("OceanofPDF returned an invalid download handoff form")
+    return action, fields
+
+
+def _parse_auto_download_url(html: str, response_url: str, book_format: str) -> str:
+    """Extract and validate the file URL from the handoff page's redirect script."""
+    match = _AUTO_DOWNLOAD_PATTERN.search(html)
+    href = downloader.get_absolute_url(response_url, match.group("url")) if match else ""
+    if not href or not _handles_url(href):
+        raise RuntimeError("OceanofPDF returned no automatic download URL")
+    if Path(urlparse(href).path).suffix.lstrip(".").casefold() != book_format:
+        raise RuntimeError("OceanofPDF returned a download URL in the wrong format")
+    return href
+
+
+def _post_download_form(
+    form: _DownloadForm,
+    detail_url: str,
+    progress_callback: Callable[[float], None] | None,
+    cancel_flag: Event | None,
+    status_callback: Callable[[str, str | None], None] | None,
+) -> BytesIO | None:
+    """Follow OceanofPDF's two POST handoff pages to the final file URL."""
+    # DOWNLOAD_HEADERS advertises Brotli, but the image has no Brotli decoder. Cloudflare
+    # compresses these HTML handoff pages with it, leaving requests.response.text as binary.
+    headers = {
+        **downloader.DOWNLOAD_HEADERS,
+        "Referer": detail_url,
+        "Accept-Encoding": "gzip, deflate",
+    }
+    hostname = urlparse(form["action"]).hostname or ""
+    user_agent = downloader.get_cf_user_agent_for_domain(hostname)
+    if user_agent:
+        headers["User-Agent"] = user_agent
+    resource_page = requests.post(
+        form["action"],
+        data=form["fields"],
+        headers=headers,
+        cookies=downloader.get_cf_cookies_for_domain(hostname),
+        proxies=network.get_proxies(form["action"]),
+        timeout=downloader.REQUEST_TIMEOUT,
+        verify=network.get_ssl_verify(form["action"]),
+    )
+    resource_page.raise_for_status()
+
+    handoff_url, handoff_fields = _parse_handoff_form(resource_page.text, resource_page.url)
+    headers["Referer"] = resource_page.url
+    handoff_page = requests.post(
+        handoff_url,
+        data=handoff_fields,
+        headers=headers,
+        proxies=network.get_proxies(handoff_url),
+        timeout=downloader.REQUEST_TIMEOUT,
+        verify=network.get_ssl_verify(handoff_url),
+    )
+    handoff_page.raise_for_status()
+
+    file_url = _parse_auto_download_url(handoff_page.text, handoff_page.url, form["format"])
+    return downloader.download_url(
+        file_url,
+        form["size"] or "",
+        progress_callback,
+        cancel_flag,
+        status_callback=status_callback,
+        referer=handoff_page.url,
+    )
+
+
+class OceanofPDFProvider:
+    """OceanofPDF adapter for the internal Direct Download provider registry."""
+
+    id = "oceanofpdf"
+    display_name = "OceanofPDF"
+
+    def is_enabled(self) -> bool:
+        if not mirrors.has_oceanofpdf_mirror_configuration():
+            return False
+        priority = config.get("SOURCE_PRIORITY", [])
+        if not isinstance(priority, list):
+            return False
+        return any(
+            isinstance(item, dict) and item.get("id") == self.id and bool(item.get("enabled", True))
+            for item in priority
+        )
+
+    def handles(self, url: str) -> bool:
+        return _handles_url(url)
+
+    def search_query(self, query: str, filters: SearchFilters) -> list[BrowseRecord]:
+        """Run one OceanofPDF query."""
+        if not self.is_enabled():
+            return []
+        base_url = mirrors.get_oceanofpdf_primary_url()
+        if not base_url:
+            return []
+        encoded_query = quote_plus(query)
+        results: list[BrowseRecord] = []
+        seen_ids: set[str] = set()
+        for page_number in range(1, _MAX_SEARCH_PAGES + 1):
+            search_url = (
+                f"{base_url}/?s={encoded_query}"
+                if page_number == 1
+                else f"{base_url}/page/{page_number}/?s={encoded_query}"
+            )
+            page = downloader.html_get_page(
+                search_url,
+                retry=2,
+                allow_bypasser_fallback=True,
+                success_delay=0,
+            )
+            html = html_response_text(page)
+            if not html:
+                break
+            soup = BeautifulSoup(html, "html.parser")
+            # OceanofPDF cannot apply Shelfmark's format/language filters on the
+            # server. Collect a bounded result set across its WordPress pages so
+            # filtered-out cards on early pages do not hide later matches.
+            for record in parse_results(html, filters):
+                if record.id in seen_ids:
+                    continue
+                seen_ids.add(record.id)
+                results.append(record)
+                if len(results) >= _MAX_SEARCH_RESULTS:
+                    return results
+            if not soup.select_one("article.entry"):
+                break
+        return results
+
+    def search(
+        self,
+        book: BookMetadata,
+        plan: ReleaseSearchPlan,
+        *,
+        expand_search: bool = False,
+        content_type: str = "ebook",
+    ) -> list[BrowseRecord]:
+        """Search useful query variants from the shared release-search context."""
+        del expand_search
+        if content_type != "ebook":
+            return []
+
+        filters = (
+            replace(plan.source_filters)
+            if plan.source_filters is not None
+            else SearchFilters(lang=plan.languages or [])
+        )
+        queries = [plan.manual_query or plan.primary_query or book.title]
+        if not plan.manual_query and plan.title_variants:
+            queries.append(plan.title_variants[0].title)
+
+        for query in dict.fromkeys(value.strip() for value in queries if value and value.strip()):
+            records = self.search_query(query, filters)
+            if records:
+                return records
+        return []
+
+    def download(
+        self,
+        book_info: BrowseRecord,
+        book_path: Path,
+        progress_callback: Callable[[float], None] | None,
+        cancel_flag: Event | None,
+        status_callback: Callable[[str, str | None], None] | None,
+    ) -> str | None:
+        detail_url = book_info.source_url or ""
+        if not _handles_url(detail_url):
+            return None
+        if status_callback:
+            status_callback("resolving", "Fetching OceanofPDF download options")
+        page = downloader.html_get_page(
+            detail_url,
+            retry=2,
+            cancel_flag=cancel_flag,
+            status_callback=status_callback,
+            allow_bypasser_fallback=True,
+            success_delay=0,
+        )
+        forms = parse_download_forms(html_response_text(page), detail_url)
+        selected = _select_download_form(forms, book_info.format)
+        if status_callback:
+            status_callback("resolving", f"Resolving {selected['format'].upper()} download")
+        data = _post_download_form(
+            selected, detail_url, progress_callback, cancel_flag, status_callback
+        )
+        if not data:
+            raise RuntimeError("OceanofPDF returned no file data")
+        if data.getbuffer().nbytes < MIN_VALID_FILE_SIZE:
+            raise RuntimeError("OceanofPDF returned a file that was too small")
+        if cancel_flag and cancel_flag.is_set():
+            return None
+
+        data.seek(0)
+        with book_path.open("wb") as output:
+            output.write(data.getbuffer())
+        if progress_callback:
+            progress_callback(100.0)
+        return detail_url

--- a/shelfmark/release_sources/direct_download/registry.py
+++ b/shelfmark/release_sources/direct_download/registry.py
@@ -1,0 +1,93 @@
+"""Provider composition and dispatch for the Direct Download release source."""
+
+import re
+from typing import TYPE_CHECKING
+
+from shelfmark.core.config import config
+from shelfmark.release_sources.direct_download.annas_archive import AnnasArchiveProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from shelfmark.release_sources import BrowseRecord
+    from shelfmark.release_sources.direct_download.common import DirectDownloadProvider
+
+
+PROVIDER_TYPES = (AnnasArchiveProvider,)
+_AA_MD5_PATTERN = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
+
+
+def create_providers() -> tuple[DirectDownloadProvider, ...]:
+    """Create request-local providers so mutable search state is not shared."""
+    return tuple(provider_type() for provider_type in PROVIDER_TYPES)
+
+
+def enabled_providers(
+    providers: Sequence[DirectDownloadProvider] | None = None,
+) -> tuple[DirectDownloadProvider, ...]:
+    if not config.get("DIRECT_DOWNLOAD_ENABLED", False):
+        return ()
+    candidates = providers if providers is not None else create_providers()
+    return tuple(provider for provider in candidates if provider.is_enabled())
+
+
+def get_unavailable_reason(
+    providers: Sequence[DirectDownloadProvider] | None = None,
+) -> str | None:
+    if not config.get("DIRECT_DOWNLOAD_ENABLED", False):
+        return "Direct Download is disabled. Enable the source in Settings."
+    if not enabled_providers(providers):
+        return (
+            "Direct Download is not configured. Enable and configure at least one "
+            "download provider in Settings."
+        )
+    return None
+
+
+def provider_by_id(
+    provider_id: str | None,
+    providers: Sequence[DirectDownloadProvider] | None = None,
+) -> DirectDownloadProvider | None:
+    if not provider_id:
+        return None
+    candidates = providers if providers is not None else create_providers()
+    return next((provider for provider in candidates if provider.id == provider_id), None)
+
+
+def provider_for_record(
+    record: BrowseRecord,
+    providers: Sequence[DirectDownloadProvider] | None = None,
+) -> DirectDownloadProvider | None:
+    """Resolve a record explicitly, retaining safe compatibility with legacy tasks."""
+    candidates = providers if providers is not None else create_providers()
+    prefix, separator, _remainder = record.id.partition(":")
+    if separator:
+        provider = provider_by_id(prefix, candidates)
+        if provider is not None:
+            return provider
+
+    if record.source_url:
+        provider = next(
+            (provider for provider in candidates if provider.handles(record.source_url)),
+            None,
+        )
+        if provider is not None:
+            return provider
+
+    # Anna's Archive records historically carried only their raw MD5. Preserve those
+    # persisted tasks without treating arbitrary unknown URLs as Anna's Archive.
+    if _AA_MD5_PATTERN.fullmatch(record.id):
+        return provider_by_id("annas_archive", candidates)
+    return None
+
+
+def provider_for_record_id(
+    record_id: str,
+    providers: Sequence[DirectDownloadProvider] | None = None,
+) -> DirectDownloadProvider | None:
+    candidates = providers if providers is not None else create_providers()
+    prefix, separator, _remainder = record_id.partition(":")
+    if separator:
+        return provider_by_id(prefix, candidates)
+    # Record lookup predates provider-qualified IDs, so unqualified IDs are AA IDs.
+    return provider_by_id("annas_archive", candidates)

--- a/shelfmark/release_sources/direct_download/registry.py
+++ b/shelfmark/release_sources/direct_download/registry.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from shelfmark.core.config import config
 from shelfmark.release_sources.direct_download.annas_archive import AnnasArchiveProvider
+from shelfmark.release_sources.direct_download.oceanofpdf import OceanofPDFProvider
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from shelfmark.release_sources.direct_download.common import DirectDownloadProvider
 
 
-PROVIDER_TYPES = (AnnasArchiveProvider,)
+PROVIDER_TYPES = (AnnasArchiveProvider, OceanofPDFProvider)
 _AA_MD5_PATTERN = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
 
 
@@ -28,7 +29,29 @@ def enabled_providers(
     if not config.get("DIRECT_DOWNLOAD_ENABLED", False):
         return ()
     candidates = providers if providers is not None else create_providers()
-    return tuple(provider for provider in candidates if provider.is_enabled())
+    enabled = [provider for provider in candidates if provider.is_enabled()]
+    priority = config.get("SOURCE_PRIORITY", [])
+    if not isinstance(priority, list):
+        return tuple(enabled)
+
+    positions = {
+        item["id"]: index
+        for index, item in enumerate(priority)
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    }
+    fallback_position = len(positions)
+
+    def _position(provider: DirectDownloadProvider) -> int:
+        if provider.id == "oceanofpdf":
+            return positions.get("oceanofpdf", fallback_position)
+        if provider.id == "annas_archive":
+            aa_positions = [
+                position for source_id, position in positions.items() if source_id != "oceanofpdf"
+            ]
+            return min(aa_positions, default=fallback_position)
+        return fallback_position
+
+    return tuple(sorted(enabled, key=_position))
 
 
 def get_unavailable_reason(

--- a/shelfmark/release_sources/direct_download/source.py
+++ b/shelfmark/release_sources/direct_download/source.py
@@ -1,0 +1,204 @@
+"""Direct Download search and release-source integration."""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+import requests
+
+from shelfmark.core.logger import setup_logger
+from shelfmark.core.utils import get_aa_content_type_dir
+from shelfmark.core.utils import is_audiobook as check_audiobook
+from shelfmark.release_sources import (
+    BrowseRecord,
+    ColumnAlign,
+    ColumnColorHint,
+    ColumnRenderType,
+    ColumnSchema,
+    Release,
+    ReleaseColumnConfig,
+    ReleaseProtocol,
+    ReleaseSource,
+    SourceUnavailableError,
+    register_source,
+)
+from shelfmark.release_sources.direct_download import registry
+from shelfmark.release_sources.direct_download.common import (
+    DirectDownloadUnavailableError,
+    RecordLookupProvider,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from shelfmark.core.models import DownloadTask
+    from shelfmark.core.search_plan import ReleaseSearchPlan
+    from shelfmark.metadata_providers import BookMetadata
+
+logger = setup_logger(__name__)
+
+
+def _browse_record_to_release(record: BrowseRecord) -> Release:
+    """Convert a browse record to a Release object.
+
+    This bridges the direct source's browse data to the generic release model.
+    """
+    provider = registry.provider_for_record(record)
+    provider_id = provider.id if provider is not None else None
+    return Release(
+        source=record.source,
+        source_id=record.id,
+        title=record.title,
+        format=record.format,
+        language=record.language,  # Top-level language for filtering
+        size=record.size,
+        download_url=record.source_url
+        or (record.download_urls[0] if record.download_urls else None),
+        info_url=record.source_url,
+        protocol=ReleaseProtocol.HTTP,
+        indexer="Direct Download",
+        content_type=record.content,  # Preserve content type from source
+        extra={
+            "author": record.author,
+            "publisher": record.publisher,
+            "year": record.year,
+            "language": record.language,
+            "preview": record.preview,
+            "description": record.description,
+            "download_urls": record.download_urls,
+            "info": record.info,
+            "direct_download_provider": provider_id,
+            # Kept for older frontends and persisted request payloads.
+            "web_provider": provider_id if provider_id != "annas_archive" else None,
+        },
+    )
+
+
+@register_source("direct_download")
+class DirectDownloadSource(ReleaseSource):
+    """Direct download source - searches web sources for books.
+
+    This wraps the search_books() functionality to provide releases
+    via the plugin interface.
+    """
+
+    name = "direct_download"
+    display_name = "Direct Download"
+    supported_content_types: ClassVar[list[str]] = ["ebook"]  # Direct downloads only support ebooks
+
+    def __init__(self) -> None:
+        """Initialize per-instance search state for direct downloads."""
+        self._providers = registry.create_providers()
+
+    @property
+    def last_search_type(self) -> str:
+        """Returns the search type used in the last search() call."""
+        provider = registry.provider_by_id("annas_archive", self._providers)
+        return str(getattr(provider, "last_search_type", "title_author"))
+
+    def get_column_config(self) -> ReleaseColumnConfig:
+        """Column configuration for Direct Download source.
+
+        Shows language, format, and size badges for each release.
+        Language is hidden on mobile; format and size are shown.
+        """
+        return ReleaseColumnConfig(
+            columns=[
+                ColumnSchema(
+                    key="extra.language",
+                    label="Language",
+                    render_type=ColumnRenderType.BADGE,
+                    align=ColumnAlign.CENTER,
+                    width="60px",
+                    hide_mobile=False,  # Language shown on mobile
+                    color_hint=ColumnColorHint(type="map", value="language"),
+                    uppercase=True,
+                ),
+                ColumnSchema(
+                    key="format",
+                    label="Format",
+                    render_type=ColumnRenderType.BADGE,
+                    align=ColumnAlign.CENTER,
+                    width="80px",
+                    hide_mobile=False,  # Format shown on mobile
+                    color_hint=ColumnColorHint(type="map", value="format"),
+                    uppercase=True,
+                ),
+                ColumnSchema(
+                    key="size",
+                    label="Size",
+                    render_type=ColumnRenderType.SIZE,
+                    align=ColumnAlign.CENTER,
+                    width="80px",
+                    hide_mobile=False,  # Size shown on mobile
+                ),
+            ],
+            grid_template="minmax(0,2fr) 60px 80px 80px",
+            supported_filters=["format", "language"],  # AA has reliable language metadata
+        )
+
+    def get_record(
+        self,
+        record_id: str,
+        *,
+        fetch_download_count: bool = True,
+    ) -> BrowseRecord | None:
+        """Resolve a direct-download record for direct-mode info/download flows."""
+        provider = registry.provider_for_record_id(record_id, self._providers)
+        if provider is None or not isinstance(provider, RecordLookupProvider):
+            return None
+        native_id = record_id.partition(":")[2] or record_id
+        return provider.get_record(native_id, fetch_download_count=fetch_download_count)
+
+    def search_results_are_releases(self) -> bool:
+        """Direct search results already represent concrete downloadable releases."""
+        return True
+
+    def get_destination_override(self, task: DownloadTask) -> Path | None:
+        """Apply Anna's Archive content-type routing when configured."""
+        if check_audiobook(task.content_type):
+            return None
+        return get_aa_content_type_dir(task.content_type)
+
+    def search(
+        self,
+        book: BookMetadata,
+        plan: ReleaseSearchPlan,
+        *,
+        expand_search: bool = False,
+        content_type: str = "ebook",
+    ) -> list[Release]:
+        """Search every enabled provider through the shared provider lifecycle."""
+        unavailable_reason = registry.get_unavailable_reason(self._providers)
+        if unavailable_reason:
+            raise DirectDownloadUnavailableError(unavailable_reason)
+
+        releases: list[Release] = []
+        unavailable_errors: list[SourceUnavailableError] = []
+        for provider in registry.enabled_providers(self._providers):
+            try:
+                records = provider.search(
+                    book,
+                    plan,
+                    expand_search=expand_search,
+                    content_type=content_type,
+                )
+            except SourceUnavailableError as exc:
+                unavailable_errors.append(exc)
+                continue
+            except (
+                RuntimeError,
+                TypeError,
+                ValueError,
+                requests.exceptions.RequestException,
+            ) as exc:
+                logger.warning("%s search failed: %s", provider.display_name, exc)
+                continue
+            releases.extend(_browse_record_to_release(record) for record in records)
+
+        if unavailable_errors and not releases:
+            raise unavailable_errors[0]
+        return releases
+
+    def is_available(self) -> bool:
+        """Check if Direct Download has been explicitly enabled and configured."""
+        return registry.get_unavailable_reason(self._providers) is None

--- a/src/frontend/src/components/OnboardingModal.tsx
+++ b/src/frontend/src/components/OnboardingModal.tsx
@@ -1,9 +1,14 @@
 import { useState, useCallback, useMemo } from 'react';
+import type { ReactNode } from 'react';
 
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
 import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useMountEffect } from '../hooks/useMountEffect';
-import type { OnboardingStep, OnboardingStepCondition } from '../services/api';
+import type {
+  OnboardingFieldGroup,
+  OnboardingStep,
+  OnboardingStepCondition,
+} from '../services/api';
 import {
   getOnboarding,
   saveOnboarding,
@@ -12,6 +17,7 @@ import {
 } from '../services/api';
 import type { SettingsField, ActionResult, ShowWhenCondition } from '../types/settings';
 import { toBooleanValue, toStringArray, toStringValue } from '../utils/objectHelpers';
+import { getOnboardingStepValidationError } from '../utils/onboardingValidation';
 import {
   TextField,
   PasswordField,
@@ -170,6 +176,50 @@ const renderField = (
   }
 };
 
+interface OnboardingFieldGroupPanelProps {
+  group: OnboardingFieldGroup;
+  children: ReactNode;
+}
+
+const OnboardingFieldGroupPanel = ({ group, children }: OnboardingFieldGroupPanelProps) => {
+  const [isOpen, setIsOpen] = useState(group.defaultOpen ?? false);
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-(--border-muted)">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-4 bg-(--bg-soft) px-4 py-3 text-left transition-colors hover:bg-(--hover-surface)"
+        onClick={() => setIsOpen((current) => !current)}
+        aria-expanded={isOpen}
+        aria-controls={`onboarding-field-group-${group.id}`}
+      >
+        <span className="min-w-0">
+          <span className="block text-sm font-semibold">{group.title}</span>
+          {group.description && (
+            <span className="mt-0.5 block text-xs opacity-60">{group.description}</span>
+          )}
+        </span>
+        <svg
+          className={`h-4 w-4 shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+        </svg>
+      </button>
+      {isOpen && (
+        <div id={`onboarding-field-group-${group.id}`} className="space-y-5 px-4 py-4">
+          {children}
+        </div>
+      )}
+    </section>
+  );
+};
+
 export const OnboardingModal = ({
   isOpen,
   onClose,
@@ -223,6 +273,7 @@ const OnboardingModalSession = ({
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showStepValidationError, setShowStepValidationError] = useState(false);
 
   useMountEffect(() => {
     const fetchOnboarding = async () => {
@@ -261,6 +312,21 @@ const OnboardingModalSession = ({
     return currentStep.fields.filter((field) => isFieldVisible(field, values));
   }, [currentStep, values]);
 
+  const groupedFieldKeys = useMemo(
+    () => new Set(currentStep?.fieldGroups?.flatMap((group) => group.fieldKeys) ?? []),
+    [currentStep],
+  );
+
+  const ungroupedFields = useMemo(
+    () => visibleFields.filter((field) => !groupedFieldKeys.has(field.key)),
+    [groupedFieldKeys, visibleFields],
+  );
+
+  const stepValidationError = useMemo(
+    () => getOnboardingStepValidationError(currentStep, values),
+    [currentStep, values],
+  );
+
   // Handle field value changes
   const handleChange = useCallback((key: string, value: unknown) => {
     setValues((prev) => ({ ...prev, [key]: value }));
@@ -268,13 +334,20 @@ const OnboardingModalSession = ({
 
   // Handle next step
   const handleNext = useCallback(() => {
+    if (stepValidationError) {
+      setShowStepValidationError(true);
+      return;
+    }
+
+    setShowStepValidationError(false);
     if (clampedStepIndex < visibleSteps.length - 1) {
       setCurrentStepIndex(clampedStepIndex + 1);
     }
-  }, [clampedStepIndex, visibleSteps.length]);
+  }, [clampedStepIndex, stepValidationError, visibleSteps.length]);
 
   // Handle previous step
   const handleBack = useCallback(() => {
+    setShowStepValidationError(false);
     if (clampedStepIndex > 0) {
       setCurrentStepIndex(clampedStepIndex - 1);
     }
@@ -415,6 +488,21 @@ const OnboardingModalSession = ({
   const isLastStep = clampedStepIndex === visibleSteps.length - 1;
   const progress = ((clampedStepIndex + 1) / visibleSteps.length) * 100;
 
+  const renderWrappedField = (field: SettingsField) => {
+    const isDisabled = 'fromEnv' in field ? (field.fromEnv ?? false) : false;
+    return (
+      <FieldWrapper key={field.key} field={field}>
+        {renderField(
+          field,
+          values[field.key],
+          (value) => handleChange(field.key, value),
+          () => handleAction(field.key),
+          isDisabled,
+        )}
+      </FieldWrapper>
+    );
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       {/* Backdrop */}
@@ -475,20 +563,24 @@ const OnboardingModalSession = ({
         {/* Content */}
         <div className="min-h-0 flex-1 overflow-y-auto">
           <div className="min-h-[280px] space-y-5 px-6 py-5">
-            {visibleFields.map((field) => {
-              const isDisabled = 'fromEnv' in field ? (field.fromEnv ?? false) : false;
+            {ungroupedFields.map(renderWrappedField)}
+            {currentStep?.fieldGroups?.map((group) => {
+              const groupFields = visibleFields.filter((field) =>
+                group.fieldKeys.includes(field.key),
+              );
+              if (groupFields.length === 0) return null;
+
               return (
-                <FieldWrapper key={field.key} field={field}>
-                  {renderField(
-                    field,
-                    values[field.key],
-                    (v) => handleChange(field.key, v),
-                    () => handleAction(field.key),
-                    isDisabled,
-                  )}
-                </FieldWrapper>
+                <OnboardingFieldGroupPanel key={group.id} group={group}>
+                  {groupFields.map(renderWrappedField)}
+                </OnboardingFieldGroupPanel>
               );
             })}
+            {showStepValidationError && stepValidationError && (
+              <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+                {stepValidationError}
+              </p>
+            )}
           </div>
         </div>
 

--- a/src/frontend/src/services/api.ts
+++ b/src/frontend/src/services/api.ts
@@ -765,6 +765,14 @@ export interface OnboardingStepCondition {
   notEmpty?: boolean;
 }
 
+export interface OnboardingFieldGroup {
+  id: string;
+  title: string;
+  description?: string;
+  fieldKeys: string[];
+  defaultOpen?: boolean;
+}
+
 export interface OnboardingStep {
   id: string;
   title: string;
@@ -772,6 +780,7 @@ export interface OnboardingStep {
   fields: SettingsField[];
   showWhen?: OnboardingStepCondition[]; // Array of conditions (all must be true)
   optional?: boolean;
+  fieldGroups?: OnboardingFieldGroup[];
 }
 
 interface OnboardingConfig {

--- a/src/frontend/src/tests/onboardingValidation.test.ts
+++ b/src/frontend/src/tests/onboardingValidation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import type { OnboardingStep } from '../services/api';
+import { getOnboardingStepValidationError } from '../utils/onboardingValidation';
+
+const makeStep = (id: string): OnboardingStep => ({
+  id,
+  title: 'Test step',
+  tab: 'download_sources',
+  fields: [],
+});
+
+describe('getOnboardingStepValidationError', () => {
+  it.each(['direct_download_setup', 'direct_download_setup_direct_mode'])(
+    'requires a mirror URL for %s',
+    (stepId) => {
+      expect(getOnboardingStepValidationError(makeStep(stepId), {})).toBe('Add at least one URL.');
+    },
+  );
+
+  it("accepts an Anna's Archive mirror URL", () => {
+    expect(
+      getOnboardingStepValidationError(makeStep('direct_download_setup'), {
+        AA_MIRROR_URLS: ['https://annas-archive.example'],
+      }),
+    ).toBeNull();
+  });
+
+  it('accepts an OceanofPDF mirror URL', () => {
+    expect(
+      getOnboardingStepValidationError(makeStep('direct_download_setup'), {
+        OCEANOFPDF_MIRROR_URLS: ['https://oceanofpdf.example'],
+      }),
+    ).toBeNull();
+  });
+
+  it('does not apply direct-download validation to other steps', () => {
+    expect(getOnboardingStepValidationError(makeStep('release_sources'), {})).toBeNull();
+  });
+});

--- a/src/frontend/src/tests/requestPayload.test.ts
+++ b/src/frontend/src/tests/requestPayload.test.ts
@@ -163,4 +163,14 @@ describe('requestPayload utilities', () => {
 
     expect(data.language).toBe('de');
   });
+
+  it('preserves the provider detail URL when downloading a direct-mode result', () => {
+    const data = buildReleaseDataFromDirectBook({
+      ...baseBook,
+      id: 'oceanofpdf:result-1',
+      source_url: 'https://oceanofpdf.com/book/result-1/',
+    });
+
+    expect(data.download_url).toBe('https://oceanofpdf.com/book/result-1/');
+  });
 });

--- a/src/frontend/src/utils/onboardingValidation.ts
+++ b/src/frontend/src/utils/onboardingValidation.ts
@@ -1,0 +1,29 @@
+import type { OnboardingStep } from '../services/api';
+
+const DIRECT_DOWNLOAD_SETUP_STEP_IDS = new Set([
+  'direct_download_setup',
+  'direct_download_setup_direct_mode',
+]);
+
+function hasMirrorUrl(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some((item) => typeof item === 'string' && item.trim().length > 0);
+  }
+
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function getOnboardingStepValidationError(
+  step: OnboardingStep | undefined,
+  values: Record<string, unknown>,
+): string | null {
+  if (!step || !DIRECT_DOWNLOAD_SETUP_STEP_IDS.has(step.id)) {
+    return null;
+  }
+
+  if (hasMirrorUrl(values.AA_MIRROR_URLS) || hasMirrorUrl(values.OCEANOFPDF_MIRROR_URLS)) {
+    return null;
+  }
+
+  return 'Add at least one URL.';
+}

--- a/src/frontend/src/utils/requestPayload.ts
+++ b/src/frontend/src/utils/requestPayload.ts
@@ -105,6 +105,7 @@ export const buildReleaseDataFromDirectBook = (book: Book) => {
     year: book.year,
     format: book.format,
     size: book.size,
+    download_url: book.source_url,
     preview: book.preview,
     content_type: 'ebook' as const,
     // Browsing a source directly means the book record IS the release record.

--- a/tests/config/test_download_settings.py
+++ b/tests/config/test_download_settings.py
@@ -446,6 +446,7 @@ def test_slow_source_options_lock_entries_until_mirror_dependencies_exist(monkey
     monkeypatch.setattr("shelfmark.core.mirrors.has_aa_mirror_configuration", lambda: True)
     monkeypatch.setattr("shelfmark.core.mirrors.has_welib_mirror_configuration", lambda: False)
     monkeypatch.setattr("shelfmark.core.mirrors.has_zlib_mirror_configuration", lambda: False)
+    monkeypatch.setattr("shelfmark.core.mirrors.has_oceanofpdf_mirror_configuration", lambda: False)
 
     options = {option["id"]: option for option in _get_slow_source_options()}
 
@@ -455,3 +456,27 @@ def test_slow_source_options_lock_entries_until_mirror_dependencies_exist(monkey
     assert options["welib"]["disabledReason"] == "Add at least one Welib mirror in Mirrors"
     assert options["zlib"]["isLocked"] is True
     assert options["zlib"]["disabledReason"] == "Add at least one Z-Library mirror in Mirrors"
+    assert options["oceanofpdf"]["isLocked"] is True
+    assert options["oceanofpdf"]["disabledReason"] == (
+        "Add at least one OceanofPDF mirror in Mirrors"
+    )
+
+
+def test_oceanofpdf_slow_source_only_requires_its_mirror(monkeypatch):
+    from shelfmark.config.settings import _get_slow_source_defaults, _get_slow_source_options
+
+    monkeypatch.setattr(
+        "shelfmark.core.config.config.get",
+        lambda key, default=None, user_id=None: False if key == "USE_CF_BYPASS" else default,
+    )
+    monkeypatch.setattr("shelfmark.core.mirrors.has_aa_mirror_configuration", lambda: True)
+    monkeypatch.setattr("shelfmark.core.mirrors.has_welib_mirror_configuration", lambda: True)
+    monkeypatch.setattr("shelfmark.core.mirrors.has_zlib_mirror_configuration", lambda: True)
+    monkeypatch.setattr("shelfmark.core.mirrors.has_oceanofpdf_mirror_configuration", lambda: True)
+
+    options = {option["id"]: option for option in _get_slow_source_options()}
+    defaults = {item["id"]: item["enabled"] for item in _get_slow_source_defaults()}
+
+    assert options["oceanofpdf"]["isLocked"] is False
+    assert options["oceanofpdf"]["disabledReason"] is None
+    assert defaults["oceanofpdf"] is True

--- a/tests/config/test_generate_env_docs.py
+++ b/tests/config/test_generate_env_docs.py
@@ -10,6 +10,7 @@ def test_generated_env_docs_use_canonical_mirror_env_vars() -> None:
         "LIBGEN_MIRROR_URLS",
         "ZLIB_MIRROR_URLS",
         "WELIB_MIRROR_URLS",
+        "OCEANOFPDF_MIRROR_URLS",
     ):
         assert f"`{canonical_var}`" in docs
 

--- a/tests/config/test_mirror_settings_migration.py
+++ b/tests/config/test_mirror_settings_migration.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 def test_mirror_settings_use_canonical_tag_lists_for_all_non_base_mirror_sets():
     import shelfmark.config.settings  # noqa: F401
-    from shelfmark.core.settings_registry import TagListField, get_settings_tab
+    from shelfmark.core.settings_registry import HeadingField, TagListField, get_settings_tab
 
     tab = get_settings_tab("mirrors")
 
@@ -14,6 +14,10 @@ def test_mirror_settings_use_canonical_tag_lists_for_all_non_base_mirror_sets():
     assert isinstance(fields["LIBGEN_MIRROR_URLS"], TagListField)
     assert isinstance(fields["ZLIB_MIRROR_URLS"], TagListField)
     assert isinstance(fields["WELIB_MIRROR_URLS"], TagListField)
+    assert isinstance(fields["OCEANOFPDF_MIRROR_URLS"], TagListField)
+    assert isinstance(fields["oceanofpdf_mirrors_heading"], HeadingField)
+    assert fields["oceanofpdf_mirrors_heading"].title == "OceanofPDF"
+    assert fields["OCEANOFPDF_MIRROR_URLS"].label == "Mirrors"
 
 
 def test_migrate_mirror_settings_does_not_seed_defaults_on_fresh_install(monkeypatch):
@@ -201,3 +205,12 @@ def test_migrate_search_page_title_skips_when_env_var_is_set(monkeypatch):
     registry.migrate_search_page_title(existing_install=True, had_existing_value=False)
 
     saves.assert_not_called()
+
+
+def test_save_normalizes_oceanofpdf_mirrors():
+    from shelfmark.config.settings import _on_save_mirrors
+
+    result = _on_save_mirrors(
+        {"OCEANOFPDF_MIRROR_URLS": ["books.example/", "https://books.example", "auto", ""]}
+    )
+    assert result["values"]["OCEANOFPDF_MIRROR_URLS"] == ["https://books.example"]

--- a/tests/core/test_mirrors_config.py
+++ b/tests/core/test_mirrors_config.py
@@ -141,3 +141,26 @@ def test_get_welib_url_template_returns_none_without_config(monkeypatch):
     monkeypatch.setattr(mirrors, "_get_config", lambda: _DummyConfig({}))
 
     assert mirrors.get_welib_url_template() is None
+
+
+def test_oceanofpdf_mirrors_normalize_and_use_first_url(monkeypatch):
+    dummy = _DummyConfig(
+        {"OCEANOFPDF_MIRROR_URLS": "books.example/, https://books.example, https://backup.example/"}
+    )
+    monkeypatch.setattr(mirrors, "_get_config", lambda: dummy)
+
+    assert mirrors.get_oceanofpdf_mirrors() == ["https://books.example", "https://backup.example"]
+    assert mirrors.get_oceanofpdf_primary_url() == "https://books.example"
+    assert mirrors.has_download_source_mirror_configuration("oceanofpdf") is True
+    assert mirrors.get_download_source_missing_mirror_reason("oceanofpdf") is None
+
+
+def test_oceanofpdf_has_no_default_mirrors(monkeypatch):
+    monkeypatch.setattr(mirrors, "_get_config", lambda: _DummyConfig({}))
+
+    assert mirrors.get_oceanofpdf_mirrors() == []
+    assert mirrors.get_oceanofpdf_primary_url() is None
+    assert mirrors.has_download_source_mirror_configuration("oceanofpdf") is False
+    assert mirrors.get_download_source_missing_mirror_reason("oceanofpdf") == (
+        "Add at least one OceanofPDF mirror in Mirrors"
+    )

--- a/tests/core/test_onboarding.py
+++ b/tests/core/test_onboarding.py
@@ -31,7 +31,7 @@ def _group_save_calls(
 
 
 def test_get_onboarding_config_uses_release_source_settings_pages():
-    from shelfmark.core.onboarding import get_onboarding_config
+    from shelfmark.core.onboarding import ONBOARDING_RELEASE_SOURCES_KEY, get_onboarding_config
 
     config = get_onboarding_config()
     steps = {step["id"]: step for step in config["steps"]}
@@ -43,8 +43,21 @@ def test_get_onboarding_config_uses_release_source_settings_pages():
     assert "audiobookbay" in steps
     assert "irc" in steps
 
+    release_source_fields = {
+        field["key"]: field for field in steps["release_sources"]["fields"] if "key" in field
+    }
+    direct_download_option = next(
+        option
+        for option in release_source_fields[ONBOARDING_RELEASE_SOURCES_KEY]["options"]
+        if option["value"] == "direct_download"
+    )
+    assert direct_download_option["description"] == (
+        "Configure your own mirror URLs for direct ebook downloads."
+    )
+
+    direct_download_field_list = steps["direct_download_setup"]["fields"]
     direct_download_fields = {
-        field["key"] for field in steps["direct_download_setup"]["fields"] if "key" in field
+        field["key"] for field in direct_download_field_list if "key" in field
     }
     direct_download_bypass_fields = {
         field["key"]
@@ -63,8 +76,45 @@ def test_get_onboarding_config_uses_release_source_settings_pages():
     assert "SOURCE_PRIORITY" not in direct_download_fields
     assert "AA_DONATOR_KEY" in direct_download_fields
     assert "AA_MIRROR_URLS" in direct_download_fields
+    assert "OCEANOFPDF_MIRROR_URLS" in direct_download_fields
+    direct_download_fields_by_key = {
+        field["key"]: field for field in direct_download_field_list if "key" in field
+    }
+    assert (
+        direct_download_fields_by_key["direct_download_setup_onboarding_heading"]["title"]
+        == "Choose at least one download source"
+    )
+    assert (
+        direct_download_fields_by_key["AA_DONATOR_KEY"]["label"]
+        == "Anna's Archive Donator Key (optional)"
+    )
+    direct_download_field_keys = [field["key"] for field in direct_download_field_list]
+    assert direct_download_field_keys.index("AA_MIRROR_URLS") < direct_download_field_keys.index(
+        "AA_DONATOR_KEY"
+    )
     assert "LIBGEN_ADDITIONAL_URLS" not in direct_download_fields
     assert "ZLIB_PRIMARY_URL" not in direct_download_fields
+    direct_download_groups = {
+        group["id"]: group for group in steps["direct_download_setup"]["fieldGroups"]
+    }
+    assert direct_download_groups["annas_archive"] == {
+        "id": "annas_archive",
+        "title": "Anna's Archive",
+        "description": "Configure mirror URLs and an optional donator API key.",
+        "fieldKeys": ["AA_MIRROR_URLS", "AA_DONATOR_KEY"],
+        "defaultOpen": True,
+    }
+    assert direct_download_groups["oceanofpdf"] == {
+        "id": "oceanofpdf",
+        "title": "OceanOfPDF",
+        "description": "Configure the mirror URL used for searches and downloads.",
+        "fieldKeys": ["OCEANOFPDF_MIRROR_URLS"],
+        "defaultOpen": False,
+    }
+    assert (
+        steps["direct_download_setup_direct_mode"]["fieldGroups"]
+        == steps["direct_download_setup"]["fieldGroups"]
+    )
     assert "EXT_BYPASSER_TIMEOUT" not in direct_download_bypass_fields
     assert "PROWLARR_ENABLED" not in prowlarr_fields
     assert "PROWLARR_AUTO_EXPAND" not in prowlarr_fields

--- a/tests/direct_download/test_handler.py
+++ b/tests/direct_download/test_handler.py
@@ -1,5 +1,6 @@
 from threading import Event
 
+from shelfmark.core.config import config
 from shelfmark.core.models import DownloadTask
 from shelfmark.release_sources.direct_download import DirectDownloadHandler
 
@@ -13,11 +14,11 @@ def test_direct_download_handler_builds_staging_filename_from_browse_record(monk
         captured["path"] = book_path
         return "https://example.com/file.epub"
 
-    import shelfmark.release_sources.direct_download as dd
+    from shelfmark.release_sources.direct_download import handler as dd
 
     monkeypatch.setattr(dd, "_download_book", fake_download_book)
     monkeypatch.setattr(
-        dd.config,
+        config,
         "get",
         lambda key, default=None: "rename" if key == "FILE_ORGANIZATION" else default,
     )
@@ -47,11 +48,11 @@ def test_direct_download_handler_uses_source_id_filename_when_organization_disab
         captured["path"] = book_path
         return "https://example.com/file.epub"
 
-    import shelfmark.release_sources.direct_download as dd
+    from shelfmark.release_sources.direct_download import handler as dd
 
     monkeypatch.setattr(dd, "_download_book", fake_download_book)
     monkeypatch.setattr(
-        dd.config,
+        config,
         "get",
         lambda key, default=None: "none" if key == "FILE_ORGANIZATION" else default,
     )
@@ -78,7 +79,7 @@ def test_direct_download_handler_skips_download_when_cancelled_before_start(monk
     def unexpected_download(*_args, **_kwargs):
         raise AssertionError("_download_book should not run when the task is already cancelled")
 
-    import shelfmark.release_sources.direct_download as dd
+    from shelfmark.release_sources.direct_download import handler as dd
 
     monkeypatch.setattr(dd, "_download_book", unexpected_download)
 
@@ -113,12 +114,12 @@ def test_direct_download_handler_removes_partial_file_when_cancelled_after_downl
         cancel_flag.set()
         return "https://example.com/file.epub"
 
-    import shelfmark.release_sources.direct_download as dd
+    from shelfmark.release_sources.direct_download import handler as dd
 
     monkeypatch.setattr(dd, "_download_book", fake_download_book)
     monkeypatch.setattr(dd, "TMP_DIR", tmp_path)
     monkeypatch.setattr(
-        dd.config,
+        config,
         "get",
         lambda key, default=None: "rename" if key == "FILE_ORGANIZATION" else default,
     )

--- a/tests/direct_download/test_oceanofpdf.py
+++ b/tests/direct_download/test_oceanofpdf.py
@@ -1,0 +1,430 @@
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+
+from shelfmark.core import mirrors
+from shelfmark.core.config import config
+from shelfmark.core.models import SearchFilters
+from shelfmark.release_sources import BrowseRecord, get_source
+from shelfmark.release_sources.direct_download import (
+    DirectDownloadHandler,
+    DirectDownloadSource,
+    handler,
+    oceanofpdf,
+)
+from shelfmark.release_sources.direct_download import annas_archive as aa
+
+SEARCH_HTML = """
+<article class="post entry" aria-label="[PDF EPUB] Dune Download">
+  <header><h2 class="entry-title">
+    <a href="https://oceanofpdf.com/authors/frank-herbert/pdf-epub-dune-download/">Dune</a>
+  </h2></header>
+  <a class="entry-image-link"><img class="entry-image" data-src="https://media.oceanofpdf.com/dune.jpg"></a>
+  <div class="postmetainfo">
+    <strong>Author: </strong>Frank Herbert<br>
+    <strong>Language: </strong>English<br>
+  </div>
+</article>
+"""
+
+DETAIL_HTML = """
+<main class="entry-content">
+  <ul><li><strong>PDF File Size</strong>: <strong>4.2 MB</strong></li></ul>
+  <form action="https://oceanofpdf.com/Fetching_Resource.php" method="post">
+    <input name="id" type="hidden" value="srv3">
+    <input name="filename" type="hidden" value="Dune_-_Frank_Herbert.pdf">
+  </form>
+</main>
+"""
+
+RESOURCE_HTML = """
+<html><body>
+  <form id="my_form" action="https://ads.example/article" method="post">
+    <input name="id" type="hidden" value="srv3">
+    <input name="filename" type="hidden" value="Dune_-_Frank_Herbert.pdf">
+  </form>
+  <script>document.getElementById('my_form').submit();</script>
+</body></html>
+"""
+
+HANDOFF_HTML = """
+<script>
+setTimeout("location.href = 'https://fs5.oceanofpdf.com/OceanofPDF.com/Dune_-_Frank_Herbert.pdf?token=abc';", 8000);
+</script>
+"""
+
+
+@pytest.fixture(autouse=True)
+def configured_mirrors(monkeypatch):
+    monkeypatch.setattr(mirrors, "get_oceanofpdf_mirrors", lambda: ["https://oceanofpdf.com"])
+
+
+def test_parse_search_page_creates_one_result_per_advertised_format():
+    results = oceanofpdf.parse_results(SEARCH_HTML, SearchFilters(format=["pdf", "epub"]))
+
+    assert [result.format for result in results] == ["pdf", "epub"]
+    assert results[0].source == "direct_download"
+    assert results[0].title == "Dune"
+    assert results[0].author == "Frank Herbert"
+    assert results[0].language == "en"
+    assert results[0].preview == "https://media.oceanofpdf.com/dune.jpg"
+    assert results[0].source_url == (
+        "https://oceanofpdf.com/authors/frank-herbert/pdf-epub-dune-download/"
+    )
+
+
+def test_parse_download_forms_extracts_post_payload_and_size():
+    forms = oceanofpdf.parse_download_forms(
+        DETAIL_HTML,
+        "https://oceanofpdf.com/authors/frank-herbert/pdf-epub-dune-download/",
+    )
+
+    assert len(forms) == 1
+    assert forms[0]["action"] == "https://oceanofpdf.com/Fetching_Resource.php"
+    assert forms[0]["fields"] == {"id": "srv3", "filename": "Dune_-_Frank_Herbert.pdf"}
+    assert forms[0]["format"] == "pdf"
+    assert forms[0]["size"] == "4.2 MB"
+
+
+def test_oceanofpdf_results_are_exposed_by_direct_download(monkeypatch):
+
+    records = oceanofpdf.parse_results(SEARCH_HTML, SearchFilters(format=["pdf", "epub"]))
+    monkeypatch.setattr(
+        config,
+        "get",
+        lambda key, default=None: {
+            "DIRECT_DOWNLOAD_ENABLED": True,
+            "SOURCE_PRIORITY": [{"id": "oceanofpdf", "enabled": True}],
+        }.get(key, default),
+    )
+    monkeypatch.setattr(
+        oceanofpdf.OceanofPDFProvider,
+        "search",
+        lambda *_args, **_kwargs: records,
+    )
+    monkeypatch.setattr(aa.AnnasArchiveProvider, "is_enabled", lambda _self: True)
+    monkeypatch.setattr(
+        aa.AnnasArchiveProvider,
+        "search",
+        lambda *_args, **_kwargs: [
+            BrowseRecord(
+                id="aa-id",
+                title="Dune",
+                source="direct_download",
+            )
+        ],
+    )
+    source = DirectDownloadSource()
+    plan = SimpleNamespace(
+        manual_query=None,
+        primary_query="Dune Frank Herbert",
+        title_variants=[SimpleNamespace(title="Dune")],
+        source_filters=None,
+        languages=None,
+    )
+
+    releases = source.search(SimpleNamespace(title="Dune"), plan)
+
+    assert [release.source for release in releases] == ["direct_download"] * 3
+    assert [release.extra.get("web_provider") for release in releases] == [
+        "oceanofpdf",
+        "oceanofpdf",
+        None,
+    ]
+    with pytest.raises(ValueError, match="Unknown release source"):
+        get_source("oceanofpdf")
+
+
+def test_handler_reuses_shared_page_and_download_helpers(monkeypatch, tmp_path):
+
+    monkeypatch.setattr(handler, "TMP_DIR", tmp_path)
+    monkeypatch.setattr(aa.downloader, "html_get_page", lambda *_args, **_kwargs: DETAIL_HTML)
+    monkeypatch.setattr(oceanofpdf, "_post_download_form", lambda *_args: BytesIO(b"x" * 12_000))
+    monkeypatch.setattr(config, "get", lambda *_args, **_kwargs: "rename")
+    progress = []
+    statuses = []
+    task = SimpleNamespace(
+        source_url="https://oceanofpdf.com/authors/frank-herbert/pdf-epub-dune-download/",
+        task_id="dune-pdf",
+        format="pdf",
+        title="Dune",
+        author="Frank Herbert",
+        year="1965",
+        size=None,
+        preview=None,
+    )
+
+    result = DirectDownloadHandler().download(
+        task,
+        SimpleNamespace(is_set=lambda: False),
+        progress.append,
+        lambda status, message: statuses.append((status, message)),
+    )
+
+    assert result == str(tmp_path / "Frank Herbert - Dune (1965).pdf")
+    assert (tmp_path / "Frank Herbert - Dune (1965).pdf").stat().st_size == 12_000
+    assert progress == [100.0]
+    assert statuses[-1] == ("resolving", "Resolving PDF download")
+
+
+def test_search_uses_configured_primary_mirror(monkeypatch):
+    monkeypatch.setattr(
+        mirrors,
+        "get_oceanofpdf_mirrors",
+        lambda: ["https://books.example", "https://backup.example"],
+    )
+    monkeypatch.setattr(
+        config,
+        "get",
+        lambda key, default=None: (
+            [{"id": "oceanofpdf", "enabled": True}] if key == "SOURCE_PRIORITY" else default
+        ),
+    )
+    fetched = []
+    fetch_options = []
+
+    def fetch(url, **kwargs):
+        fetched.append(url)
+        fetch_options.append(kwargs)
+        if "/page/2/" in url:
+            return "<main>No more results</main>"
+        return SEARCH_HTML.replace("oceanofpdf.com", "books.example")
+
+    monkeypatch.setattr(oceanofpdf.downloader, "html_get_page", fetch)
+    results = oceanofpdf.OceanofPDFProvider().search_query(
+        "Dune & Herbert", SearchFilters(format=["pdf"])
+    )
+
+    assert fetched == [
+        "https://books.example/?s=Dune+%26+Herbert",
+        "https://books.example/page/2/?s=Dune+%26+Herbert",
+    ]
+    assert fetch_options == [
+        {"retry": 2, "allow_bypasser_fallback": True, "success_delay": 0},
+        {"retry": 2, "allow_bypasser_fallback": True, "success_delay": 0},
+    ]
+    assert len(results) == 1
+    assert results[0].source_url.startswith("https://books.example/")
+
+
+def test_search_aggregates_later_pages_when_first_page_formats_are_filtered(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "get",
+        lambda key, default=None: (
+            [{"id": "oceanofpdf", "enabled": True}] if key == "SOURCE_PRIORITY" else default
+        ),
+    )
+    pdf_only = SEARCH_HTML.replace("[PDF EPUB]", "[PDF]")
+    third_page = SEARCH_HTML.replace("[PDF EPUB]", "[EPUB]").replace("Dune", "Dune EPUB")
+    fourth_page = (
+        SEARCH_HTML.replace("[PDF EPUB]", "[EPUB]")
+        .replace("Dune", "Shadows")
+        .replace("pdf-epub-dune-download", "epub-shadows-download")
+    )
+    fetched = []
+
+    def fetch(url, **kwargs):
+        fetched.append(url)
+        if "/page/3/" in url:
+            return third_page
+        if "/page/4/" in url:
+            return fourth_page
+        if "/page/5/" in url:
+            return "<main>No more results</main>"
+        if "/page/2/" in url:
+            return pdf_only
+        return pdf_only
+
+    monkeypatch.setattr(oceanofpdf.downloader, "html_get_page", fetch)
+
+    results = oceanofpdf.OceanofPDFProvider().search_query("shadow", SearchFilters(format=["epub"]))
+
+    assert fetched == [
+        "https://oceanofpdf.com/?s=shadow",
+        "https://oceanofpdf.com/page/2/?s=shadow",
+        "https://oceanofpdf.com/page/3/?s=shadow",
+        "https://oceanofpdf.com/page/4/?s=shadow",
+        "https://oceanofpdf.com/page/5/?s=shadow",
+    ]
+    assert [(result.title, result.format) for result in results] == [
+        ("Dune EPUB", "epub"),
+        ("Shadows", "epub"),
+    ]
+
+
+def test_search_stops_after_result_limit_and_deduplicates(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "get",
+        lambda key, default=None: (
+            [{"id": "oceanofpdf", "enabled": True}] if key == "SOURCE_PRIORITY" else default
+        ),
+    )
+    fetched = []
+
+    def result_page(start, count):
+        return "".join(
+            SEARCH_HTML.replace("[PDF EPUB]", "[EPUB]")
+            .replace("Dune Download", f"Book {number} Download")
+            .replace(">Dune<", f">Book {number}<")
+            .replace("pdf-epub-dune-download", f"epub-book-{number}-download")
+            for number in range(start, start + count)
+        )
+
+    def fetch(url, **kwargs):
+        fetched.append(url)
+        return result_page(1, 13) if "/page/2/" not in url else result_page(13, 13)
+
+    monkeypatch.setattr(oceanofpdf.downloader, "html_get_page", fetch)
+
+    results = oceanofpdf.OceanofPDFProvider().search_query("books", SearchFilters(format=["epub"]))
+
+    assert len(results) == 25
+    assert len({result.id for result in results}) == 25
+    assert fetched == [
+        "https://oceanofpdf.com/?s=books",
+        "https://oceanofpdf.com/page/2/?s=books",
+    ]
+
+
+def test_search_stops_pagination_when_site_returns_no_cards(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "get",
+        lambda key, default=None: (
+            [{"id": "oceanofpdf", "enabled": True}] if key == "SOURCE_PRIORITY" else default
+        ),
+    )
+    fetched = []
+
+    def fetch(url, **kwargs):
+        fetched.append(url)
+        return "<main>No more results</main>"
+
+    monkeypatch.setattr(oceanofpdf.downloader, "html_get_page", fetch)
+
+    assert oceanofpdf.OceanofPDFProvider().search_query("missing", SearchFilters()) == []
+    assert fetched == ["https://oceanofpdf.com/?s=missing"]
+
+
+def test_unconfigured_provider_does_not_search(monkeypatch):
+    monkeypatch.setattr(mirrors, "get_oceanofpdf_mirrors", lambda: [])
+    monkeypatch.setattr(config, "get", lambda *_args: True)
+
+    def unexpected_fetch(*args, **kwargs):
+        pytest.fail("Unconfigured OceanofPDF must not make a request")
+
+    monkeypatch.setattr(oceanofpdf.downloader, "html_get_page", unexpected_fetch)
+    provider = oceanofpdf.OceanofPDFProvider()
+    assert provider.is_enabled() is False
+    assert provider.search_query("Dune", SearchFilters()) == []
+    assert provider.handles("https://oceanofpdf.com/book") is False
+
+
+def test_priority_toggle_disables_provider_even_with_a_mirror(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "get",
+        lambda key, default=None: (
+            [{"id": "oceanofpdf", "enabled": False}] if key == "SOURCE_PRIORITY" else default
+        ),
+    )
+
+    assert oceanofpdf.OceanofPDFProvider().is_enabled() is False
+
+
+def test_configured_domains_control_download_form_routing(monkeypatch):
+    monkeypatch.setattr(mirrors, "get_oceanofpdf_mirrors", lambda: ["https://books.example"])
+    provider = oceanofpdf.OceanofPDFProvider()
+    assert provider.handles("https://files.books.example/book") is True
+    assert provider.handles("https://books.example.evil.test/book") is False
+    assert provider.handles("https://otherbooks.example/book") is False
+    assert provider.handles("ftp://books.example/book") is False
+    assert oceanofpdf.parse_download_forms(DETAIL_HTML, "https://books.example/book") == []
+    forms = oceanofpdf.parse_download_forms(
+        DETAIL_HTML.replace(
+            "https://oceanofpdf.com/Fetching_Resource.php", "/Fetching_Resource.php"
+        ),
+        "https://books.example/book",
+    )
+    assert forms[0]["action"] == "https://books.example/Fetching_Resource.php"
+
+
+def test_post_download_form_follows_explicit_handoff(monkeypatch):
+    class FakeResponse:
+        def __init__(self, url, content, content_type):
+            self.url = url
+            self.content = content
+            self.text = content.decode()
+            self.headers = {"content-type": content_type}
+
+        def raise_for_status(self):
+            return None
+
+    post_responses = iter(
+        [
+            FakeResponse(
+                "https://oceanofpdf.com/Fetching_Resource.php",
+                RESOURCE_HTML.encode(),
+                "text/html; charset=UTF-8",
+            ),
+            FakeResponse(
+                "https://ads.example/article",
+                HANDOFF_HTML.encode(),
+                "text/html; charset=UTF-8",
+            ),
+        ]
+    )
+    calls = []
+
+    def post(url, **kwargs):
+        calls.append((url, kwargs))
+        return next(post_responses)
+
+    downloaded = BytesIO(b"x" * 12_000)
+    download_calls = []
+    monkeypatch.setattr(oceanofpdf.requests, "post", post)
+    monkeypatch.setattr(oceanofpdf.downloader, "get_cf_cookies_for_domain", lambda _host: {})
+    monkeypatch.setattr(
+        oceanofpdf.downloader,
+        "download_url",
+        lambda *args, **kwargs: download_calls.append((args, kwargs)) or downloaded,
+    )
+    form = oceanofpdf.parse_download_forms(DETAIL_HTML, "https://oceanofpdf.com/book")[0]
+
+    result = oceanofpdf._post_download_form(form, "https://oceanofpdf.com/book", None, None, None)
+
+    assert result is not None
+    assert result is downloaded
+    assert [url for url, _kwargs in calls] == [
+        "https://oceanofpdf.com/Fetching_Resource.php",
+        "https://ads.example/article",
+    ]
+    assert calls[1][1]["data"] == {
+        "id": "srv3",
+        "filename": "Dune_-_Frank_Herbert.pdf",
+    }
+    assert calls[0][1]["headers"]["Accept-Encoding"] == "gzip, deflate"
+    assert download_calls[0][0][0] == (
+        "https://fs5.oceanofpdf.com/OceanofPDF.com/Dune_-_Frank_Herbert.pdf?token=abc"
+    )
+
+
+def test_auto_download_url_rejects_an_external_file_host():
+    with pytest.raises(RuntimeError, match="no automatic download URL"):
+        oceanofpdf._parse_auto_download_url(
+            "<script>location.href = 'https://ads.example/file.pdf';</script>",
+            "https://ads.example/article",
+            "pdf",
+        )
+
+
+def test_auto_download_url_rejects_wrong_format():
+    with pytest.raises(RuntimeError, match="wrong format"):
+        oceanofpdf._parse_auto_download_url(
+            "<script>location.href = 'https://fs5.oceanofpdf.com/file.epub';</script>",
+            "https://ads.example/article",
+            "pdf",
+        )

--- a/tests/direct_download/test_search_budget.py
+++ b/tests/direct_download/test_search_budget.py
@@ -10,13 +10,16 @@ a challenge failure became a gateway timeout (issue #1276).
 
 import pytest
 
-import shelfmark.release_sources.direct_download as dd
 from shelfmark.core import search_deadline
+from shelfmark.release_sources.direct_download import annas_archive as aa
+from shelfmark.release_sources.direct_download import source as dd
 
 
 @pytest.fixture(autouse=True)
-def _no_ambient_deadline():
+def _no_ambient_deadline(monkeypatch):
     token = search_deadline._current.set(None)
+    monkeypatch.setattr(dd.registry, "get_unavailable_reason", lambda _providers: None)
+    monkeypatch.setattr(dd.registry, "enabled_providers", lambda providers: (providers[0],))
     yield
     search_deadline._current.reset(token)
 
@@ -35,13 +38,13 @@ class _Selector:
 def test_fetch_search_table_gives_up_when_the_budget_is_spent(monkeypatch):
     """Every mirror shares the protection, so another mirror is another wasted solve."""
     fetches: list[str] = []
-    monkeypatch.setattr(dd.downloader, "html_get_page", lambda url, **_k: fetches.append(url) or "")
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
+    monkeypatch.setattr(aa.downloader, "html_get_page", lambda url, **_k: fetches.append(url) or "")
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
 
     with search_deadline.search_deadline(60) as deadline:
         deadline.event.set()
-        with pytest.raises(dd.SearchUnavailableError) as excinfo:
-            dd._fetch_search_table("https://annas-archive.gl/search?q=dune", _Selector())
+        with pytest.raises(aa.SearchUnavailableError) as excinfo:
+            aa._fetch_search_table("https://annas-archive.gl/search?q=dune", _Selector())
 
     assert fetches == [], "no fetch should have been attempted"
     assert "ran out of time" in str(excinfo.value)
@@ -49,11 +52,11 @@ def test_fetch_search_table_gives_up_when_the_budget_is_spent(monkeypatch):
 
 def test_fetch_search_table_runs_normally_within_budget(monkeypatch):
     page = "<html><body><main><table><tbody></tbody></table></main></body></html>"
-    monkeypatch.setattr(dd.downloader, "html_get_page", lambda _url, **_k: page)
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
+    monkeypatch.setattr(aa.downloader, "html_get_page", lambda _url, **_k: page)
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
 
     with search_deadline.search_deadline(60):
-        html, table = dd._fetch_search_table("https://annas-archive.gl/search?q=dune", _Selector())
+        html, table = aa._fetch_search_table("https://annas-archive.gl/search?q=dune", _Selector())
 
     assert table is not None
     assert html == page
@@ -98,8 +101,8 @@ def test_title_variants_stop_once_the_budget_is_spent(monkeypatch):
             deadline.event.set()
         return []
 
-    monkeypatch.setattr(dd, "search_books", fake_search_books)
-    monkeypatch.setattr(dd, "_ensure_direct_download_available", lambda: None)
+    monkeypatch.setattr(aa, "search_books", fake_search_books)
+    monkeypatch.setattr(aa, "ensure_available", lambda: None)
 
     source = dd.DirectDownloadSource()
     with search_deadline.search_deadline(60):
@@ -111,8 +114,8 @@ def test_title_variants_stop_once_the_budget_is_spent(monkeypatch):
 
 def test_all_title_variants_run_within_budget(monkeypatch):
     queries: list[str] = []
-    monkeypatch.setattr(dd, "search_books", lambda q, _f: queries.append(q) or [])
-    monkeypatch.setattr(dd, "_ensure_direct_download_available", lambda: None)
+    monkeypatch.setattr(aa, "search_books", lambda q, _f: queries.append(q) or [])
+    monkeypatch.setattr(aa, "ensure_available", lambda: None)
 
     source = dd.DirectDownloadSource()
     with search_deadline.search_deadline(60):
@@ -134,8 +137,8 @@ def test_language_filter_retry_is_skipped_on_a_spent_budget(monkeypatch):
                 deadline.event.set()
         return []
 
-    monkeypatch.setattr(dd, "search_books", fake_search_books)
-    monkeypatch.setattr(dd, "_ensure_direct_download_available", lambda: None)
+    monkeypatch.setattr(aa, "search_books", fake_search_books)
+    monkeypatch.setattr(aa, "ensure_available", lambda: None)
 
     source = dd.DirectDownloadSource()
     with search_deadline.search_deadline(60):

--- a/tests/direct_download/test_search_challenge_false_positive.py
+++ b/tests/direct_download/test_search_challenge_false_positive.py
@@ -10,6 +10,8 @@ unsolved challenge, telling users to go fix a bypasser that had just succeeded.
 import pytest
 from bs4 import Tag
 
+from shelfmark.release_sources.direct_download import annas_archive as aa
+
 # Verbatim from a live annas-archive.pk 403, trimmed of nothing that matters: this is
 # what an interstitial actually looks like, and it is under a kilobyte.
 DDOS_GUARD_INTERSTITIAL = (
@@ -58,7 +60,7 @@ class _Selector:
 
 
 def _patch_pages(monkeypatch, pages: list[str]):
-    import shelfmark.release_sources.direct_download as dd
+    from shelfmark.release_sources.direct_download import source as dd
 
     calls: list[str] = []
 
@@ -66,8 +68,8 @@ def _patch_pages(monkeypatch, pages: list[str]):
         calls.append(url)
         return pages[len(calls) - 1] if len(calls) <= len(pages) else ""
 
-    monkeypatch.setattr(dd.downloader, "html_get_page", fake_get)
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["a", "b"])
+    monkeypatch.setattr(aa.downloader, "html_get_page", fake_get)
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["a", "b"])
     return dd, calls
 
 
@@ -80,8 +82,6 @@ def search_logs():
     """
     import logging
 
-    import shelfmark.release_sources.direct_download as dd
-
     messages: list[str] = []
 
     class _Capture(logging.Handler):
@@ -89,38 +89,37 @@ def search_logs():
             messages.append(record.getMessage())
 
     handler = _Capture()
-    dd.logger.addHandler(handler)
-    previous = dd.logger.level
-    dd.logger.setLevel(logging.DEBUG)
+    aa.logger.addHandler(handler)
+    previous = aa.logger.level
+    aa.logger.setLevel(logging.DEBUG)
     # Logger.setLevel only invalidates the is-enabled cache through the manager, which
     # these loggers are not registered with; without this the DEBUG line stays filtered.
-    dd.logger._cache.clear()
+    aa.logger._cache.clear()
     try:
         yield messages
     finally:
-        dd.logger.removeHandler(handler)
-        dd.logger.setLevel(previous)
+        aa.logger.removeHandler(handler)
+        aa.logger.setLevel(previous)
 
 
 def test_the_size_guard_is_what_separates_a_real_page_from_an_interstitial():
     """The two inputs this bug turned on, checked directly."""
-    import shelfmark.release_sources.direct_download as dd
     from shelfmark.bypass.challenge import MAX_CHALLENGE_HTML_CHARS
 
     assert len(DDOS_GUARD_INTERSTITIAL) < MAX_CHALLENGE_HTML_CHARS
     assert len(AA_PAGE_WITHOUT_TABLE) > MAX_CHALLENGE_HTML_CHARS
     # Both contain "ddos-guard"; only one is a challenge.
     assert "ddos-guard" in AA_PAGE_WITHOUT_TABLE.lower()
-    assert dd._looks_like_challenge_page(DDOS_GUARD_INTERSTITIAL)
-    assert not dd._looks_like_challenge_page(AA_PAGE_WITHOUT_TABLE)
+    assert aa._looks_like_challenge_page(DDOS_GUARD_INTERSTITIAL)
+    assert not aa._looks_like_challenge_page(AA_PAGE_WITHOUT_TABLE)
 
 
 def test_real_aa_page_without_a_table_is_not_reported_as_a_challenge(monkeypatch):
     """The #1289 failure: a served AA page raised "unsolved protection challenge"."""
-    dd, calls = _patch_pages(monkeypatch, [AA_PAGE_WITHOUT_TABLE])
+    _dd, calls = _patch_pages(monkeypatch, [AA_PAGE_WITHOUT_TABLE])
     selector = _Selector(["https://real.test", "https://other.test"])
 
-    html, table = dd._fetch_search_table("https://real.test/search?q=malice", selector)
+    html, table = aa._fetch_search_table("https://real.test/search?q=malice", selector)
 
     assert table is None
     assert html == AA_PAGE_WITHOUT_TABLE
@@ -131,22 +130,22 @@ def test_real_aa_page_without_a_table_is_not_reported_as_a_challenge(monkeypatch
 
 def test_aa_markers_win_over_challenge_markers_on_the_same_page(monkeypatch):
     """Ordering, not just the size guard, keeps a marker-carrying AA page readable."""
-    dd, _calls = _patch_pages(monkeypatch, [AA_PAGE_WITHOUT_TABLE])
-    monkeypatch.setattr(dd, "_looks_like_challenge_page", lambda _html: True)
+    _dd, _calls = _patch_pages(monkeypatch, [AA_PAGE_WITHOUT_TABLE])
+    monkeypatch.setattr(aa, "_looks_like_challenge_page", lambda _html: True)
     selector = _Selector(["https://real.test", "https://other.test"])
 
-    _html, table = dd._fetch_search_table("https://real.test/search?q=malice", selector)
+    _html, table = aa._fetch_search_table("https://real.test/search?q=malice", selector)
 
     assert table is None
 
 
 def test_genuine_interstitial_still_raises(monkeypatch):
     """The behaviour the check exists for is untouched."""
-    dd, _calls = _patch_pages(monkeypatch, [DDOS_GUARD_INTERSTITIAL])
+    _dd, _calls = _patch_pages(monkeypatch, [DDOS_GUARD_INTERSTITIAL])
     selector = _Selector(["https://real.test", "https://other.test"])
 
-    with pytest.raises(dd.SearchUnavailableError, match="protection challenge"):
-        dd._fetch_search_table("https://real.test/search?q=malice", selector)
+    with pytest.raises(aa.SearchUnavailableError, match="protection challenge"):
+        aa._fetch_search_table("https://real.test/search?q=malice", selector)
 
     assert selector.quarantined == []
 
@@ -156,10 +155,10 @@ def test_results_table_is_still_returned(monkeypatch):
     page = AA_PAGE_WITHOUT_TABLE.replace(
         "<main>", "<main><table><tbody><tr><td>Malice</td></tr></tbody></table>"
     )
-    dd, _calls = _patch_pages(monkeypatch, [page])
+    _dd, _calls = _patch_pages(monkeypatch, [page])
     selector = _Selector(["https://real.test"])
 
-    _html, table = dd._fetch_search_table("https://real.test/search?q=malice", selector)
+    _html, table = aa._fetch_search_table("https://real.test/search?q=malice", selector)
 
     assert isinstance(table, Tag)
 
@@ -171,10 +170,10 @@ def test_untabled_page_is_fingerprinted_in_the_log(monkeypatch, search_logs):
     rather than reverse-engineered: size, whether the size guard applied, the AA markers
     found, and the challenge marker (or its absence).
     """
-    dd, _calls = _patch_pages(monkeypatch, [AA_PAGE_WITHOUT_TABLE])
+    _dd, _calls = _patch_pages(monkeypatch, [AA_PAGE_WITHOUT_TABLE])
     selector = _Selector(["https://real.test", "https://other.test"])
 
-    dd._fetch_search_table("https://real.test/search?q=malice", selector)
+    aa._fetch_search_table("https://real.test/search?q=malice", selector)
 
     verdict = next(m for m in search_logs if "no results table" in m)
     assert f"bytes={len(AA_PAGE_WITHOUT_TABLE)}" in verdict
@@ -190,11 +189,11 @@ def test_untabled_page_is_fingerprinted_in_the_log(monkeypatch, search_logs):
 
 def test_interstitial_fingerprint_names_the_marker_that_proved_it(monkeypatch, search_logs):
     """The same line must also settle the opposite case, without needing the body."""
-    dd, _calls = _patch_pages(monkeypatch, [DDOS_GUARD_INTERSTITIAL])
+    _dd, _calls = _patch_pages(monkeypatch, [DDOS_GUARD_INTERSTITIAL])
     selector = _Selector(["https://real.test", "https://other.test"])
 
-    with pytest.raises(dd.SearchUnavailableError):
-        dd._fetch_search_table("https://real.test/search?q=malice", selector)
+    with pytest.raises(aa.SearchUnavailableError):
+        aa._fetch_search_table("https://real.test/search?q=malice", selector)
 
     verdict = next(m for m in search_logs if "no results table" in m)
     assert "over_challenge_size_cap=False" in verdict
@@ -204,14 +203,14 @@ def test_interstitial_fingerprint_names_the_marker_that_proved_it(monkeypatch, s
 
 def test_fingerprint_failure_never_breaks_a_search(monkeypatch):
     """Diagnostics are best-effort; a bug in them must not cost the user their search."""
-    dd, _calls = _patch_pages(monkeypatch, [AA_PAGE_WITHOUT_TABLE])
+    _dd, _calls = _patch_pages(monkeypatch, [AA_PAGE_WITHOUT_TABLE])
 
     def boom(_html):
         raise RuntimeError("marker scan blew up")
 
-    monkeypatch.setattr(dd, "challenge_marker", boom)
+    monkeypatch.setattr(aa, "challenge_marker", boom)
     selector = _Selector(["https://real.test", "https://other.test"])
 
-    _html, table = dd._fetch_search_table("https://real.test/search?q=malice", selector)
+    _html, table = aa._fetch_search_table("https://real.test/search?q=malice", selector)
 
     assert table is None

--- a/tests/direct_download/test_search_page_reuse.py
+++ b/tests/direct_download/test_search_page_reuse.py
@@ -11,8 +11,10 @@ solve, tens of seconds for nothing. See issue #1285.
 import pytest
 from bs4 import BeautifulSoup
 
-import shelfmark.release_sources.direct_download as dd
 from shelfmark.core import search_deadline
+from shelfmark.core.config import config
+from shelfmark.core.models import SearchFilters
+from shelfmark.release_sources.direct_download import annas_archive as aa
 
 
 @pytest.fixture(autouse=True)
@@ -39,9 +41,9 @@ _PAGE = "<html><body><main><table><tbody></tbody></table></main></body></html>"
 def _count_fetches(monkeypatch) -> list[str]:
     fetched: list[str] = []
     monkeypatch.setattr(
-        dd.downloader, "html_get_page", lambda url, **_k: fetched.append(url) or _PAGE
+        aa.downloader, "html_get_page", lambda url, **_k: fetched.append(url) or _PAGE
     )
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
     return fetched
 
 
@@ -49,9 +51,9 @@ def test_repeated_url_is_fetched_once_within_one_search(monkeypatch):
     fetched = _count_fetches(monkeypatch)
     url = "https://annas-archive.gl/search?q=dune"
 
-    with dd._search_page_reuse():
-        first_html, first_table = dd._fetch_search_table(url, _Selector())
-        second_html, second_table = dd._fetch_search_table(url, _Selector())
+    with aa.search_page_reuse():
+        first_html, first_table = aa._fetch_search_table(url, _Selector())
+        second_html, second_table = aa._fetch_search_table(url, _Selector())
 
     assert fetched == [url], "the second ask should have been served from the search's cache"
     assert first_html == second_html
@@ -61,9 +63,9 @@ def test_repeated_url_is_fetched_once_within_one_search(monkeypatch):
 def test_distinct_urls_are_still_fetched_separately(monkeypatch):
     fetched = _count_fetches(monkeypatch)
 
-    with dd._search_page_reuse():
-        dd._fetch_search_table("https://annas-archive.gl/search?q=dune", _Selector())
-        dd._fetch_search_table("https://annas-archive.gl/search?q=dune&lang=en", _Selector())
+    with aa.search_page_reuse():
+        aa._fetch_search_table("https://annas-archive.gl/search?q=dune", _Selector())
+        aa._fetch_search_table("https://annas-archive.gl/search?q=dune&lang=en", _Selector())
 
     assert len(fetched) == 2
 
@@ -73,10 +75,10 @@ def test_cache_does_not_leak_between_searches(monkeypatch):
     fetched = _count_fetches(monkeypatch)
     url = "https://annas-archive.gl/search?q=dune"
 
-    with dd._search_page_reuse():
-        dd._fetch_search_table(url, _Selector())
-    with dd._search_page_reuse():
-        dd._fetch_search_table(url, _Selector())
+    with aa.search_page_reuse():
+        aa._fetch_search_table(url, _Selector())
+    with aa.search_page_reuse():
+        aa._fetch_search_table(url, _Selector())
 
     assert fetched == [url, url]
 
@@ -86,8 +88,8 @@ def test_without_the_context_every_fetch_still_goes_out(monkeypatch):
     fetched = _count_fetches(monkeypatch)
     url = "https://annas-archive.gl/search?q=dune"
 
-    dd._fetch_search_table(url, _Selector())
-    dd._fetch_search_table(url, _Selector())
+    aa._fetch_search_table(url, _Selector())
+    aa._fetch_search_table(url, _Selector())
 
     assert fetched == [url, url]
 
@@ -97,12 +99,12 @@ def test_a_failure_is_not_cached(monkeypatch):
     fetched = _count_fetches(monkeypatch)
     url = "https://annas-archive.gl/search?q=dune"
 
-    with dd._search_page_reuse():
+    with aa.search_page_reuse():
         with search_deadline.search_deadline(60) as deadline:
             deadline.event.set()
-            with pytest.raises(dd.SearchUnavailableError):
-                dd._fetch_search_table(url, _Selector())
-        dd._fetch_search_table(url, _Selector())
+            with pytest.raises(aa.SearchUnavailableError):
+                aa._fetch_search_table(url, _Selector())
+        aa._fetch_search_table(url, _Selector())
 
     assert fetched == [url], "the successful retry should be the only fetch"
 
@@ -119,14 +121,14 @@ def test_a_give_up_page_is_not_cached(monkeypatch):
     parked = "<html><body>This domain is for sale.</body></html>"
     fetched: list[str] = []
     monkeypatch.setattr(
-        dd.downloader, "html_get_page", lambda url, **_k: fetched.append(url) or parked
+        aa.downloader, "html_get_page", lambda url, **_k: fetched.append(url) or parked
     )
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
     url = "https://annas-archive.gl/search?q=dune"
 
-    with dd._search_page_reuse():
-        assert dd._fetch_search_table(url, _Selector()) == (parked, None)
-        assert dd._fetch_search_table(url, _Selector()) == (parked, None)
+    with aa.search_page_reuse():
+        assert aa._fetch_search_table(url, _Selector()) == (parked, None)
+        assert aa._fetch_search_table(url, _Selector()) == (parked, None)
 
     assert fetched == [url, url], "the second pass must not inherit the first's give-up"
 
@@ -136,14 +138,14 @@ def test_a_genuinely_empty_result_is_still_cached(monkeypatch):
     empty = "<html><body><main>No files found. <a href='/md5/x'>x</a></main></body></html>"
     fetched: list[str] = []
     monkeypatch.setattr(
-        dd.downloader, "html_get_page", lambda url, **_k: fetched.append(url) or empty
+        aa.downloader, "html_get_page", lambda url, **_k: fetched.append(url) or empty
     )
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
     url = "https://annas-archive.gl/search?q=nothing"
 
-    with dd._search_page_reuse():
-        assert dd._fetch_search_table(url, _Selector()) == (empty, None)
-        assert dd._fetch_search_table(url, _Selector()) == (empty, None)
+    with aa.search_page_reuse():
+        assert aa._fetch_search_table(url, _Selector()) == (empty, None)
+        assert aa._fetch_search_table(url, _Selector()) == (empty, None)
 
     assert fetched == [url], "an empty answer is an answer; re-solving for it buys nothing"
 
@@ -152,7 +154,7 @@ def test_language_retry_reuses_the_page_it_already_fetched(monkeypatch):
     """The end-to-end shape: language-from-path makes both passes build the same URL."""
     fetched = _count_fetches(monkeypatch)
 
-    original_get = dd.config.get
+    original_get = config.get
 
     def _fake_get(key: str, default=None, user_id=None):
         del user_id
@@ -160,15 +162,15 @@ def test_language_retry_reuses_the_page_it_already_fetched(monkeypatch):
             return True
         return original_get(key, default)
 
-    monkeypatch.setattr(dd.config, "get", _fake_get)
-    monkeypatch.setattr(dd.network, "get_aa_base_url", lambda: "https://annas-archive.gl")
+    monkeypatch.setattr(config, "get", _fake_get)
+    monkeypatch.setattr(aa.network, "get_aa_base_url", lambda: "https://annas-archive.gl")
 
-    filters_with_lang = dd.SearchFilters(lang=["en"])
-    filters_without = dd.SearchFilters()
+    filters_with_lang = SearchFilters(lang=["en"])
+    filters_without = SearchFilters()
 
-    with dd._search_page_reuse():
-        dd.search_books("dune", filters_with_lang)
-        dd.search_books("dune", filters_without)
+    with aa.search_page_reuse():
+        aa.search_books("dune", filters_with_lang)
+        aa.search_books("dune", filters_without)
 
     assert len(fetched) == 1, f"both passes build the same URL, got {fetched}"
     assert "lang=" not in fetched[0]
@@ -179,12 +181,12 @@ def test_soup_reuse_is_safe_for_repeated_parsing(monkeypatch):
     page = (
         "<html><body><main><table><tbody><tr><td>row</td></tr></tbody></table></main></body></html>"
     )
-    monkeypatch.setattr(dd.downloader, "html_get_page", lambda _url, **_k: page)
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
+    monkeypatch.setattr(aa.downloader, "html_get_page", lambda _url, **_k: page)
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["https://annas-archive.gl"])
 
-    with dd._search_page_reuse():
-        _, first = dd._fetch_search_table("https://annas-archive.gl/search?q=dune", _Selector())
-        _, second = dd._fetch_search_table("https://annas-archive.gl/search?q=dune", _Selector())
+    with aa.search_page_reuse():
+        _, first = aa._fetch_search_table("https://annas-archive.gl/search?q=dune", _Selector())
+        _, second = aa._fetch_search_table("https://annas-archive.gl/search?q=dune", _Selector())
 
     assert first is not None
     assert second is not None

--- a/tests/direct_download/test_search_parked_mirror.py
+++ b/tests/direct_download/test_search_parked_mirror.py
@@ -8,6 +8,8 @@ rotation and every later search pays for it again.
 import pytest
 from bs4 import Tag
 
+from shelfmark.release_sources.direct_download import annas_archive as aa
+
 PARKED_PAGE = """<!doctype html><html><head><title>annas-archive.li</title></head>
 <body><h1>This domain is for sale</h1><p>Inquire now. Buy this domain.</p></body></html>"""
 
@@ -48,7 +50,7 @@ class _Selector:
 
 def _patch_pages(monkeypatch, pages: list[str]):
     """Serve `pages` in order, recording the URL each call was made against."""
-    import shelfmark.release_sources.direct_download as dd
+    from shelfmark.release_sources.direct_download import source as dd
 
     calls: list[str] = []
 
@@ -56,16 +58,16 @@ def _patch_pages(monkeypatch, pages: list[str]):
         calls.append(url)
         return pages[len(calls) - 1] if len(calls) <= len(pages) else ""
 
-    monkeypatch.setattr(dd.downloader, "html_get_page", fake_get)
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["a", "b", "c"])
+    monkeypatch.setattr(aa.downloader, "html_get_page", fake_get)
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["a", "b", "c"])
     return dd, calls
 
 
 def test_parked_mirror_is_quarantined_and_search_retries_next_mirror(monkeypatch):
-    dd, calls = _patch_pages(monkeypatch, [PARKED_PAGE, AA_RESULTS_PAGE])
+    _dd, calls = _patch_pages(monkeypatch, [PARKED_PAGE, AA_RESULTS_PAGE])
     selector = _Selector(["https://parked.test", "https://real.test"])
 
-    html, table = dd._fetch_search_table("https://parked.test/search?q=dune", selector)
+    html, table = aa._fetch_search_table("https://parked.test/search?q=dune", selector)
 
     assert selector.quarantined == ["https://parked.test"]
     assert isinstance(table, Tag)
@@ -76,10 +78,10 @@ def test_parked_mirror_is_quarantined_and_search_retries_next_mirror(monkeypatch
 
 def test_genuinely_empty_aa_result_does_not_quarantine(monkeypatch):
     """'No files found.' is a real answer from a healthy mirror."""
-    dd, _calls = _patch_pages(monkeypatch, [AA_EMPTY_PAGE])
+    _dd, _calls = _patch_pages(monkeypatch, [AA_EMPTY_PAGE])
     selector = _Selector(["https://real.test", "https://other.test"])
 
-    html, table = dd._fetch_search_table("https://real.test/search?q=zzz", selector)
+    html, table = aa._fetch_search_table("https://real.test/search?q=zzz", selector)
 
     assert selector.quarantined == []
     assert table is None
@@ -92,29 +94,28 @@ def test_challenge_page_is_reported_not_passed_off_as_an_empty_result(monkeypatc
     The mirror is alive and holds our clearance, so it must not be quarantined - but
     returning it as "no table" made the caller tell the user their query found nothing.
     """
-    dd, _calls = _patch_pages(monkeypatch, [DDOS_GUARD_PAGE])
+    _dd, _calls = _patch_pages(monkeypatch, [DDOS_GUARD_PAGE])
     selector = _Selector(["https://real.test", "https://other.test"])
 
-    with pytest.raises(dd.SearchUnavailableError, match="protection challenge"):
-        dd._fetch_search_table("https://real.test/search?q=dune", selector)
+    with pytest.raises(aa.SearchUnavailableError, match="protection challenge"):
+        aa._fetch_search_table("https://real.test/search?q=dune", selector)
 
     assert selector.quarantined == []
 
 
 def test_unreachable_mirror_raises_search_unavailable(monkeypatch):
-    dd, _calls = _patch_pages(monkeypatch, [""])
+    _dd, _calls = _patch_pages(monkeypatch, [""])
     selector = _Selector(["https://real.test"])
 
     try:
-        dd._fetch_search_table("https://real.test/search?q=dune", selector)
-    except dd.SearchUnavailableError:
+        aa._fetch_search_table("https://real.test/search?q=dune", selector)
+    except aa.SearchUnavailableError:
         return
     raise AssertionError("expected SearchUnavailableError")
 
 
 def test_recorded_failure_reason_is_surfaced_to_the_caller(monkeypatch):
     """The concrete give-up reason html_get_page stashed replaces the generic line."""
-    import shelfmark.release_sources.direct_download as dd
 
     reason = "Anna's Archive returned 403 (blocked) and no bypasser is enabled."
 
@@ -122,10 +123,10 @@ def test_recorded_failure_reason_is_surfaced_to_the_caller(monkeypatch):
         selector.last_failure = reason
         return ""
 
-    monkeypatch.setattr(dd.downloader, "html_get_page", fake_get)
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["a"])
+    monkeypatch.setattr(aa.downloader, "html_get_page", fake_get)
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["a"])
     selector = _Selector(["https://real.test"])
     selector.last_failure = None
 
-    with pytest.raises(dd.SearchUnavailableError, match="403 .blocked."):
-        dd._fetch_search_table("https://real.test/search?q=dune", selector)
+    with pytest.raises(aa.SearchUnavailableError, match="403 .blocked."):
+        aa._fetch_search_table("https://real.test/search?q=dune", selector)

--- a/tests/direct_download/test_search_queries.py
+++ b/tests/direct_download/test_search_queries.py
@@ -1,8 +1,10 @@
+from shelfmark.core.config import config
 from shelfmark.core.models import SearchFilters
 from shelfmark.core.search_plan import build_release_search_plan
 from shelfmark.metadata_providers import BookMetadata
 from shelfmark.release_sources import BrowseRecord
 from shelfmark.release_sources.direct_download import DirectDownloadSource
+from shelfmark.release_sources.direct_download import annas_archive as aa
 
 
 def _browse_record(record_id: str, title: str) -> BrowseRecord:
@@ -10,9 +12,9 @@ def _browse_record(record_id: str, title: str) -> BrowseRecord:
 
 
 def _enable_direct_download(monkeypatch):
-    import shelfmark.release_sources.direct_download as dd
+    from shelfmark.release_sources.direct_download import source as dd
 
-    original_get = dd.config.get
+    original_get = config.get
 
     def _fake_get(key: str, default=None, user_id=None):
         del user_id
@@ -20,7 +22,7 @@ def _enable_direct_download(monkeypatch):
             return True
         return original_get(key, default)
 
-    monkeypatch.setattr(dd.config, "get", _fake_get)
+    monkeypatch.setattr(config, "get", _fake_get)
     monkeypatch.setattr("shelfmark.core.mirrors.has_aa_mirror_configuration", lambda: True)
     return dd
 
@@ -33,9 +35,9 @@ class TestDirectDownloadSearchQueries:
             captured.append(query)
             return []
 
-        dd = _enable_direct_download(monkeypatch)
+        _enable_direct_download(monkeypatch)
 
-        monkeypatch.setattr(dd, "search_books", fake_search_books)
+        monkeypatch.setattr(aa, "search_books", fake_search_books)
 
         source = DirectDownloadSource()
         book = BookMetadata(
@@ -75,9 +77,9 @@ class TestDirectDownloadSearchQueries:
             captured.append((query, filters.lang))
             return records_by_query[query]
 
-        dd = _enable_direct_download(monkeypatch)
+        _enable_direct_download(monkeypatch)
 
-        monkeypatch.setattr(dd, "search_books", fake_search_books)
+        monkeypatch.setattr(aa, "search_books", fake_search_books)
 
         source = DirectDownloadSource()
         book = BookMetadata(
@@ -119,9 +121,9 @@ class TestDirectDownloadSearchQueries:
                 return []
             return fallback_results[query]
 
-        dd = _enable_direct_download(monkeypatch)
+        _enable_direct_download(monkeypatch)
 
-        monkeypatch.setattr(dd, "search_books", fake_search_books)
+        monkeypatch.setattr(aa, "search_books", fake_search_books)
 
         source = DirectDownloadSource()
         book = BookMetadata(
@@ -157,9 +159,9 @@ class TestDirectDownloadSearchQueries:
                 return []
             return [_browse_record("manual-1", "Manual result")]
 
-        dd = _enable_direct_download(monkeypatch)
+        _enable_direct_download(monkeypatch)
 
-        monkeypatch.setattr(dd, "search_books", fake_search_books)
+        monkeypatch.setattr(aa, "search_books", fake_search_books)
 
         source = DirectDownloadSource()
         book = BookMetadata(
@@ -188,9 +190,9 @@ class TestDirectDownloadSearchQueries:
 
 
 def _patch_path_language(monkeypatch, enabled: bool = True):
-    import shelfmark.release_sources.direct_download as dd
+    from shelfmark.release_sources.direct_download import source as dd
 
-    original_get = dd.config.get
+    original_get = config.get
 
     def _fake_get(key: str, default=None, user_id=None):
         del user_id
@@ -198,7 +200,7 @@ def _patch_path_language(monkeypatch, enabled: bool = True):
             return enabled
         return original_get(key, default)
 
-    monkeypatch.setattr(dd.config, "get", _fake_get)
+    monkeypatch.setattr(config, "get", _fake_get)
     return dd
 
 
@@ -228,59 +230,59 @@ def _make_row(distant_path: str, language: str = "", record_id: str = "rec-1") -
 
 
 def test_detects_bracketed_language_from_distant_path(monkeypatch):
-    dd = _patch_path_language(monkeypatch)
+    _patch_path_language(monkeypatch)
     row = _row_from_html(_make_row(r"lgli/N:\comics1\emule\2021.08.01\[BD FR] Scrameustache.cbz"))
-    record = dd._parse_search_result_row(row)
+    record = aa._parse_search_result_row(row)
     assert record is not None
     assert record.language == "fr"
     assert record.download_path is not None
 
 
 def test_detects_mixed_case_bracketed_language(monkeypatch):
-    dd = _patch_path_language(monkeypatch)
+    _patch_path_language(monkeypatch)
     row = _row_from_html(_make_row(r"lgli/V:\comics\_0DAY3\[Fr]\BDs [Fr]\!Pdf\S\Book.pdf"))
-    record = dd._parse_search_result_row(row)
+    record = aa._parse_search_result_row(row)
     assert record is not None
     assert record.language == "fr"
 
 
 def test_overrides_unknown_language_with_path_detection(monkeypatch):
-    dd = _patch_path_language(monkeypatch)
+    _patch_path_language(monkeypatch)
     row = _row_from_html(_make_row(r"lgli/V:\comics\_0DAY3\[Fr]\Book.pdf", language="unknown"))
-    record = dd._parse_search_result_row(row)
+    record = aa._parse_search_result_row(row)
     assert record is not None
     assert record.language == "fr"
 
 
 def test_sets_unknown_when_path_has_no_language(monkeypatch):
-    dd = _patch_path_language(monkeypatch)
+    _patch_path_language(monkeypatch)
     row = _row_from_html(_make_row(r"lgli/N:\comics1\emule\NoLanguageHere.epub"))
-    record = dd._parse_search_result_row(row)
+    record = aa._parse_search_result_row(row)
     assert record is not None
     assert record.language == "unknown"
 
 
 def test_avoids_en_false_positive_when_french_present(monkeypatch):
-    dd = _patch_path_language(monkeypatch)
+    _patch_path_language(monkeypatch)
     row = _row_from_html(
         _make_row(r"lgli/V:\comics\_0DAY2\Stripboeken Frans - BD en Français\[BD Fr] Book.cbr")
     )
-    record = dd._parse_search_result_row(row)
+    record = aa._parse_search_result_row(row)
     assert record is not None
     assert record.language == "fr"
 
 
 def test_keeps_row_with_missing_language_when_toggle_disabled(monkeypatch):
-    dd = _patch_path_language(monkeypatch, enabled=False)
+    _patch_path_language(monkeypatch, enabled=False)
     row = _row_from_html(_make_row(r"lgli/N:\comics1\[BD FR] Scrameustache.cbz"))
-    record = dd._parse_search_result_row(row)
+    record = aa._parse_search_result_row(row)
     assert record is not None
     assert record.language is None
 
 
 def test_keeps_sparse_lgli_row(monkeypatch):
     """lgli rows missing author/publisher/year must not be dropped."""
-    dd = _patch_path_language(monkeypatch)
+    _patch_path_language(monkeypatch)
     html = r"""
     <tr>
       <td><a href="/md5/sparse-1"><img src="cover.jpg"></a></td>
@@ -292,7 +294,7 @@ def test_keeps_sparse_lgli_row(monkeypatch):
       <td><span>lgli/N:\comics1\ftp\[BD.FR] French Comics\Book.cbz</span></td>
     </tr>
     """
-    record = dd._parse_search_result_row(_row_from_html(html))
+    record = aa._parse_search_result_row(_row_from_html(html))
     assert record is not None
     assert record.id == "sparse-1"
     assert record.language == "fr"
@@ -300,9 +302,9 @@ def test_keeps_sparse_lgli_row(monkeypatch):
 
 
 def test_search_books_filters_locally_when_path_language_enabled(monkeypatch):
-    dd = _patch_path_language(monkeypatch)
-    monkeypatch.setattr(dd.network, "get_aa_base_url", lambda: "https://mirror.example")
-    monkeypatch.setattr(dd.network, "AAMirrorSelector", lambda: object())
+    _patch_path_language(monkeypatch)
+    monkeypatch.setattr(aa.network, "get_aa_base_url", lambda: "https://mirror.example")
+    monkeypatch.setattr(aa.network, "AAMirrorSelector", lambda: object())
 
     captured_url: dict[str, str] = {}
 
@@ -332,9 +334,9 @@ def test_search_books_filters_locally_when_path_language_enabled(monkeypatch):
         </table>
         """
 
-    monkeypatch.setattr(dd.downloader, "html_get_page", _fake_html_get_page)
+    monkeypatch.setattr(aa.downloader, "html_get_page", _fake_html_get_page)
 
-    records = dd.search_books("demo", SearchFilters(lang=["fr"], format=["pdf"]))
+    records = aa.search_books("demo", SearchFilters(lang=["fr"], format=["pdf"]))
 
     assert "&lang=" not in captured_url["url"]
     assert len(records) == 1
@@ -343,9 +345,8 @@ def test_search_books_filters_locally_when_path_language_enabled(monkeypatch):
 
 
 def test_book_matches_requested_languages_logic():
-    import shelfmark.release_sources.direct_download as dd
 
-    assert dd._book_matches_requested_languages(None, {"fr"}) is True
-    assert dd._book_matches_requested_languages(None, set()) is True
-    assert dd._book_matches_requested_languages("en", {"fr"}) is False
-    assert dd._book_matches_requested_languages("fr", {"fr"}) is True
+    assert aa._book_matches_requested_languages(None, {"fr"}) is True
+    assert aa._book_matches_requested_languages(None, set()) is True
+    assert aa._book_matches_requested_languages("en", {"fr"}) is False
+    assert aa._book_matches_requested_languages("fr", {"fr"}) is True

--- a/tests/direct_download/test_source_availability.py
+++ b/tests/direct_download/test_source_availability.py
@@ -51,6 +51,23 @@ def test_direct_download_source_is_available_when_enabled_and_configured(monkeyp
     assert source.is_available() is True
 
 
+def test_oceanofpdf_can_make_source_available_without_aa(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "get",
+        _fake_config_get(
+            {
+                "DIRECT_DOWNLOAD_ENABLED": True,
+                "SOURCE_PRIORITY": [{"id": "oceanofpdf", "enabled": True}],
+            }
+        ),
+    )
+    monkeypatch.setattr("shelfmark.core.mirrors.has_aa_mirror_configuration", lambda: False)
+    monkeypatch.setattr("shelfmark.core.mirrors.has_oceanofpdf_mirror_configuration", lambda: True)
+
+    assert DirectDownloadSource().is_available() is True
+
+
 def test_get_source_priority_disables_entries_without_required_mirrors(monkeypatch):
 
     monkeypatch.setattr(
@@ -66,6 +83,7 @@ def test_get_source_priority_disables_entries_without_required_mirrors(monkeypat
                 "SOURCE_PRIORITY": [
                     {"id": "welib", "enabled": True},
                     {"id": "zlib", "enabled": True},
+                    {"id": "oceanofpdf", "enabled": True},
                 ],
             }
         ),
@@ -81,6 +99,7 @@ def test_get_source_priority_disables_entries_without_required_mirrors(monkeypat
     assert priority["libgen"] is True
     assert priority["welib"] is False
     assert priority["zlib"] is True
+    assert "oceanofpdf" not in priority
 
 
 def test_is_configured_zlib_link_uses_configured_mirror_domains(monkeypatch):

--- a/tests/direct_download/test_source_availability.py
+++ b/tests/direct_download/test_source_availability.py
@@ -2,7 +2,9 @@ from types import SimpleNamespace
 
 import pytest
 
+from shelfmark.core.config import config
 from shelfmark.release_sources.direct_download import DirectDownloadSource, SearchUnavailableError
+from shelfmark.release_sources.direct_download import annas_archive as aa
 
 
 def _fake_config_get(values: dict[str, object]):
@@ -14,9 +16,8 @@ def _fake_config_get(values: dict[str, object]):
 
 
 def test_direct_download_source_is_unavailable_when_disabled(monkeypatch):
-    import shelfmark.release_sources.direct_download as dd
 
-    monkeypatch.setattr(dd.config, "get", _fake_config_get({"DIRECT_DOWNLOAD_ENABLED": False}))
+    monkeypatch.setattr(config, "get", _fake_config_get({"DIRECT_DOWNLOAD_ENABLED": False}))
     monkeypatch.setattr("shelfmark.core.mirrors.has_aa_mirror_configuration", lambda: True)
 
     source = DirectDownloadSource()
@@ -28,9 +29,8 @@ def test_direct_download_source_is_unavailable_when_disabled(monkeypatch):
 
 
 def test_direct_download_source_is_unavailable_without_aa_mirrors(monkeypatch):
-    import shelfmark.release_sources.direct_download as dd
 
-    monkeypatch.setattr(dd.config, "get", _fake_config_get({"DIRECT_DOWNLOAD_ENABLED": True}))
+    monkeypatch.setattr(config, "get", _fake_config_get({"DIRECT_DOWNLOAD_ENABLED": True}))
     monkeypatch.setattr("shelfmark.core.mirrors.has_aa_mirror_configuration", lambda: False)
 
     source = DirectDownloadSource()
@@ -42,9 +42,8 @@ def test_direct_download_source_is_unavailable_without_aa_mirrors(monkeypatch):
 
 
 def test_direct_download_source_is_available_when_enabled_and_configured(monkeypatch):
-    import shelfmark.release_sources.direct_download as dd
 
-    monkeypatch.setattr(dd.config, "get", _fake_config_get({"DIRECT_DOWNLOAD_ENABLED": True}))
+    monkeypatch.setattr(config, "get", _fake_config_get({"DIRECT_DOWNLOAD_ENABLED": True}))
     monkeypatch.setattr("shelfmark.core.mirrors.has_aa_mirror_configuration", lambda: True)
 
     source = DirectDownloadSource()
@@ -53,10 +52,9 @@ def test_direct_download_source_is_available_when_enabled_and_configured(monkeyp
 
 
 def test_get_source_priority_disables_entries_without_required_mirrors(monkeypatch):
-    import shelfmark.release_sources.direct_download as dd
 
     monkeypatch.setattr(
-        dd.config,
+        config,
         "get",
         _fake_config_get(
             {
@@ -77,7 +75,7 @@ def test_get_source_priority_disables_entries_without_required_mirrors(monkeypat
     monkeypatch.setattr("shelfmark.core.mirrors.has_welib_mirror_configuration", lambda: False)
     monkeypatch.setattr("shelfmark.core.mirrors.has_zlib_mirror_configuration", lambda: True)
 
-    priority = {item["id"]: item["enabled"] for item in dd._get_source_priority()}
+    priority = {item["id"]: item["enabled"] for item in aa._get_source_priority()}
 
     assert priority["aa-fast"] is False
     assert priority["libgen"] is True
@@ -86,12 +84,11 @@ def test_get_source_priority_disables_entries_without_required_mirrors(monkeypat
 
 
 def test_is_configured_zlib_link_uses_configured_mirror_domains(monkeypatch):
-    import shelfmark.release_sources.direct_download as dd
 
     monkeypatch.setattr(
         "shelfmark.core.mirrors.get_zlib_cookie_domains",
         lambda: {"custom-zlib.example"},
     )
 
-    assert dd._is_configured_zlib_link("https://custom-zlib.example/books/example") is True
-    assert dd._is_configured_zlib_link("https://other-zlib.example/books/example") is False
+    assert aa._is_configured_zlib_link("https://custom-zlib.example/books/example") is True
+    assert aa._is_configured_zlib_link("https://other-zlib.example/books/example") is False

--- a/tests/direct_download/test_untabled_page_names_the_answering_mirror.py
+++ b/tests/direct_download/test_untabled_page_names_the_answering_mirror.py
@@ -11,6 +11,8 @@ import logging
 
 import pytest
 
+from shelfmark.release_sources.direct_download import annas_archive as aa
+
 # A protection challenge, so the fingerprint line fires without looking like AA.
 CHALLENGE_PAGE = (
     "<html><head><title>DDOS-GUARD</title>"
@@ -26,7 +28,6 @@ def search_logs():
     setup_logger builds loggers outside the standard hierarchy, so their records never
     reach the root handler caplog installs - see tests/bypass/test_ddg_cookie_reuse.py.
     """
-    import shelfmark.release_sources.direct_download as dd
 
     messages: list[str] = []
 
@@ -35,15 +36,15 @@ def search_logs():
             messages.append(record.getMessage())
 
     handler = _Capture()
-    dd.logger.addHandler(handler)
-    previous = dd.logger.level
-    dd.logger.setLevel(logging.DEBUG)
-    dd.logger._cache.clear()
+    aa.logger.addHandler(handler)
+    previous = aa.logger.level
+    aa.logger.setLevel(logging.DEBUG)
+    aa.logger._cache.clear()
     try:
         yield messages
     finally:
-        dd.logger.removeHandler(handler)
-        dd.logger.setLevel(previous)
+        aa.logger.removeHandler(handler)
+        aa.logger.setLevel(previous)
 
 
 class _Selector:
@@ -62,7 +63,6 @@ ANSWERED = "https://annas-archive.pk/search?q=Ken+follett"
 
 
 def test_the_fingerprint_names_the_mirror_that_answered(monkeypatch, search_logs):
-    import shelfmark.release_sources.direct_download as dd
 
     def fake_get(url, **kwargs):
         # The caller must ask for it, or there is nothing to report.
@@ -71,11 +71,11 @@ def test_the_fingerprint_names_the_mirror_that_answered(monkeypatch, search_logs
         # What an internal rotation looks like from the outside: a different host.
         return CHALLENGE_PAGE, ANSWERED
 
-    monkeypatch.setattr(dd.downloader, "html_get_page", fake_get)
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["a"])
+    monkeypatch.setattr(aa.downloader, "html_get_page", fake_get)
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["a"])
 
-    with pytest.raises(dd.SearchUnavailableError):
-        dd._fetch_search_table_uncached(REQUESTED, _Selector())
+    with pytest.raises(aa.SearchUnavailableError):
+        aa._fetch_search_table_uncached(REQUESTED, _Selector())
 
     fingerprint = [m for m in search_logs if m.startswith("Search page has no results table")]
     assert len(fingerprint) == 1
@@ -85,13 +85,12 @@ def test_the_fingerprint_names_the_mirror_that_answered(monkeypatch, search_logs
 
 def test_a_downloader_that_reports_no_url_falls_back_to_the_request(monkeypatch, search_logs):
     """The plain-string shape stays supported; the line is still worth having."""
-    import shelfmark.release_sources.direct_download as dd
 
-    monkeypatch.setattr(dd.downloader, "html_get_page", lambda _url, **_k: CHALLENGE_PAGE)
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["a"])
+    monkeypatch.setattr(aa.downloader, "html_get_page", lambda _url, **_k: CHALLENGE_PAGE)
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["a"])
 
-    with pytest.raises(dd.SearchUnavailableError):
-        dd._fetch_search_table_uncached(REQUESTED, _Selector())
+    with pytest.raises(aa.SearchUnavailableError):
+        aa._fetch_search_table_uncached(REQUESTED, _Selector())
 
     fingerprint = [m for m in search_logs if m.startswith("Search page has no results table")]
     assert len(fingerprint) == 1
@@ -100,15 +99,14 @@ def test_a_downloader_that_reports_no_url_falls_back_to_the_request(monkeypatch,
 
 def test_the_empty_body_give_up_survives_the_tuple_shape(monkeypatch):
     """`("", url)` is truthy, so the exhaustion check has to read the body."""
-    import shelfmark.release_sources.direct_download as dd
 
-    monkeypatch.setattr(dd.downloader, "html_get_page", lambda _url, **_k: ("", REQUESTED))
-    monkeypatch.setattr(dd.network, "get_available_aa_urls", lambda: ["a"])
+    monkeypatch.setattr(aa.downloader, "html_get_page", lambda _url, **_k: ("", REQUESTED))
+    monkeypatch.setattr(aa.network, "get_available_aa_urls", lambda: ["a"])
 
     selector = _Selector()
     selector.last_failure = "Every mirror refused the connection."
 
-    with pytest.raises(dd.SearchUnavailableError) as excinfo:
-        dd._fetch_search_table_uncached(REQUESTED, selector)
+    with pytest.raises(aa.SearchUnavailableError) as excinfo:
+        aa._fetch_search_table_uncached(REQUESTED, selector)
 
     assert "Every mirror refused the connection." in str(excinfo.value)

--- a/tests/direct_download/test_web_providers.py
+++ b/tests/direct_download/test_web_providers.py
@@ -183,3 +183,31 @@ def test_provider_failure_is_suppressed_when_another_provider_succeeds(monkeypat
     releases = source.search(SimpleNamespace(title="Example"), SimpleNamespace())
 
     assert [release.source_id for release in releases] == ["working:1"]
+
+
+def test_provider_search_order_follows_slow_source_priority(monkeypatch):
+    class Provider:
+        def __init__(self, provider_id):
+            self.id = provider_id
+
+        def is_enabled(self):
+            return True
+
+    monkeypatch.setattr(
+        registry.config,
+        "get",
+        lambda key, default=None: {
+            "DIRECT_DOWNLOAD_ENABLED": True,
+            "SOURCE_PRIORITY": [
+                {"id": "oceanofpdf", "enabled": True},
+                {"id": "aa-slow-nowait", "enabled": True},
+            ],
+        }.get(key, default),
+    )
+
+    providers = (Provider("annas_archive"), Provider("oceanofpdf"))
+
+    assert [provider.id for provider in registry.enabled_providers(providers)] == [
+        "oceanofpdf",
+        "annas_archive",
+    ]

--- a/tests/direct_download/test_web_providers.py
+++ b/tests/direct_download/test_web_providers.py
@@ -1,0 +1,185 @@
+from types import SimpleNamespace
+
+import pytest
+
+from shelfmark.core.models import SearchFilters
+from shelfmark.release_sources.direct_download import handler, registry
+from shelfmark.release_sources.direct_download.common import ParsedSearchResult, parse_search_page
+
+
+def test_shared_parser_accepts_provider_specific_extraction():
+    from bs4 import BeautifulSoup, Tag
+
+    soup = BeautifulSoup('<li data-url="https://books.example/book">Example</li>', "html.parser")
+
+    def extract(item: Tag) -> ParsedSearchResult:
+        return ParsedSearchResult(
+            key=item["data-url"],
+            title=item.get_text(strip=True),
+            formats=("epub", "pdf"),
+            language="English",
+            source_url=item["data-url"],
+        )
+
+    records = parse_search_page(
+        soup,
+        SearchFilters(format=["epub"], lang=["en"]),
+        provider_id="example",
+        item_selector="li",
+        extract_item=extract,
+    )
+
+    assert len(records) == 1
+    assert records[0].id.startswith("example:")
+    assert records[0].format == "epub"
+    assert records[0].language == "en"
+
+
+def test_web_provider_registry_dispatches_without_source_changes(monkeypatch, tmp_path):
+    from shelfmark.release_sources.direct_download import source as dd
+
+    source_url = "https://books.example/example.epub"
+
+    class ExampleProvider:
+        id = "example"
+        display_name = "Example"
+
+        def is_enabled(self):
+            return True
+
+        def handles(self, url):
+            return url.startswith("https://books.example/")
+
+        def search(self, book, plan, **kwargs):
+            del book, plan, kwargs
+            return [
+                dd.BrowseRecord(
+                    id="example:1",
+                    title="Example",
+                    source="direct_download",
+                    format="epub",
+                    source_url=source_url,
+                )
+            ]
+
+        def download(self, book_info, book_path, *callbacks):
+            del book_info, callbacks
+            book_path.write_bytes(b"x" * 12_000)
+            return source_url
+
+    monkeypatch.setattr(registry, "PROVIDER_TYPES", (ExampleProvider,))
+    monkeypatch.setattr(
+        registry.config,
+        "get",
+        lambda key, default=None: True if key == "DIRECT_DOWNLOAD_ENABLED" else default,
+    )
+    source = dd.DirectDownloadSource()
+    plan = SimpleNamespace(
+        manual_query="Example",
+        primary_query=None,
+        source_filters=None,
+        languages=None,
+    )
+    releases = source.search(SimpleNamespace(title="Example"), plan)
+    assert len(releases) == 1
+    release = releases[0]
+    record = ExampleProvider().search(SimpleNamespace(), plan)[0]
+    destination = tmp_path / "example.epub"
+
+    assert release.extra["web_provider"] == "example"
+    assert handler._download_book(record, destination) == source_url
+    assert destination.stat().st_size == 12_000
+
+
+def test_md5_record_routes_to_annas_archive_cascade(monkeypatch, tmp_path):
+    from threading import Event
+
+    from shelfmark.release_sources.direct_download import annas_archive
+    from shelfmark.release_sources.direct_download import source as dd
+
+    record = dd.BrowseRecord(
+        id="0123456789abcdef0123456789abcdef",
+        title="Example",
+        source="direct_download",
+        format="epub",
+    )
+    destination = tmp_path / "example.epub"
+    cancel_flag = Event()
+    calls = []
+
+    def download(*args):
+        calls.append(args)
+        return "https://mirror.example/file.epub"
+
+    monkeypatch.setattr(annas_archive, "download_book", download)
+
+    assert handler._download_book(record, destination, cancel_flag=cancel_flag) == (
+        "https://mirror.example/file.epub"
+    )
+    assert calls == [(record, destination, None, cancel_flag, None)]
+
+
+def test_unknown_url_is_not_silently_routed_to_annas_archive(monkeypatch, tmp_path):
+    from shelfmark.release_sources.direct_download import annas_archive
+
+    monkeypatch.setattr(
+        annas_archive,
+        "download_book",
+        lambda *_args, **_kwargs: pytest.fail("unknown provider reached Anna's Archive"),
+    )
+    record = handler.BrowseRecord(
+        id="unknown-record",
+        title="Example",
+        source="direct_download",
+        source_url="https://unknown.example/book",
+    )
+
+    with pytest.raises(RuntimeError, match="No Direct Download provider owns"):
+        handler._download_book(record, tmp_path / "example.epub")
+
+
+def test_provider_failure_is_suppressed_when_another_provider_succeeds(monkeypatch):
+    from shelfmark.release_sources import BrowseRecord
+    from shelfmark.release_sources.direct_download.common import (
+        DirectDownloadUnavailableError,
+    )
+    from shelfmark.release_sources.direct_download.source import DirectDownloadSource
+
+    class FailingProvider:
+        id = "failing"
+        display_name = "Failing"
+
+        def is_enabled(self):
+            return True
+
+        def search(self, *_args, **_kwargs):
+            raise DirectDownloadUnavailableError("provider unavailable")
+
+    class WorkingProvider:
+        id = "working"
+        display_name = "Working"
+
+        def is_enabled(self):
+            return True
+
+        def search(self, *_args, **_kwargs):
+            return [
+                BrowseRecord(
+                    id="working:1",
+                    title="Example",
+                    source="direct_download",
+                    source_url="https://working.example/book",
+                )
+            ]
+
+    monkeypatch.setattr(
+        registry.config,
+        "get",
+        lambda key, default=None: True if key == "DIRECT_DOWNLOAD_ENABLED" else default,
+    )
+    source = DirectDownloadSource()
+    source._providers = (FailingProvider(), WorkingProvider())
+
+    releases = source.search(SimpleNamespace(title="Example"), SimpleNamespace())
+
+    assert [release.source_id for release in releases] == ["working:1"]


### PR DESCRIPTION
This pull request refactors direct downloads into an extensible, provider-based system, which allows Shelfmark to support sources beyond Anna’s Archive.

It also adds OceanofPDF as a direct-download provider (#1149), and includes mirror selection and onboarding support.

It also fixes the CI workflow by converting GitHub Container Registry image names to lowercase. This prevents publishing failures when a GitHub username contains uppercase letters.

Please note that I made this mostly with AI-assistance, and I understand that is a rather large pull request. I tested it and it works, though.