### PR TITLE
feat(languages): add pt-BR and pt-PT as distinct language entries

### DIFF
--- a/data/book-languages.json
+++ b/data/book-languages.json
@@ -7,6 +7,8 @@
     { "language": "German", "code": "de", "aliases": ["deu", "ger"] },
     { "language": "Italian", "code": "it", "aliases": ["ita"] },
     { "language": "Portuguese", "code": "pt", "aliases": ["por"] },
+    { "language": "Portuguese (Brazil)", "code": "pt-BR", "aliases": ["pt-br", "brazilian portuguese", "portugues brasileiro", "portugues (brasil)"] },
+    { "language": "Portuguese (Portugal)", "code": "pt-PT", "aliases": ["pt-pt", "european portuguese", "portugues europeu", "portugues (portugal)"] },
     { "language": "Polish", "code": "pl", "aliases": ["pol"] },
     { "language": "Bulgarian", "code": "bg", "aliases": ["bul"] },
     { "language": "Dutch", "code": "nl", "aliases": ["dut", "nld"] },

--- a/tests/core/test_languages.py
+++ b/tests/core/test_languages.py
@@ -242,6 +242,40 @@ class TestCodesDoNotShadowEachOther:
             assert normalize_language(code) == code, f"{code} resolved elsewhere"
 
 
+class TestPortugueseVariants:
+    """Brazilian and European Portuguese are distinct entries alongside the
+    unqualified 'pt', mirroring the 'zh' / 'zh-Hant' split (issue #1320)."""
+
+    def test_unqualified_portuguese_is_unchanged(self):
+        assert normalize_language("pt") == "pt"
+        assert normalize_language("por") == "pt"
+        assert normalize_language("Portuguese") == "pt"
+
+    @pytest.mark.parametrize(
+        "spelling",
+        ["pt-BR", "pt-br", "pt_BR", "pt‑BR", "Brazilian Portuguese", "portugues brasileiro"],
+    )
+    def test_brazilian_portuguese_resolves(self, spelling):
+        assert normalize_language(spelling) == "pt-BR"
+
+    @pytest.mark.parametrize(
+        "spelling", ["pt-PT", "pt-pt", "pt_PT", "European Portuguese", "portugues europeu"]
+    )
+    def test_european_portuguese_resolves(self, spelling):
+        assert normalize_language(spelling) == "pt-PT"
+
+    def test_accented_portuguese_names_resolve(self):
+        assert normalize_language("Português (Brasil)") == "pt-BR"
+        assert normalize_language("Português (Portugal)") == "pt-PT"
+
+    def test_variants_do_not_shadow_the_base_code(self):
+        # 'pt' still resolves to itself even though 'pt-BR' / 'pt-PT' share its
+        # prefix and appear later in the data file.
+        assert normalize_language("pt") == "pt"
+        assert normalize_language("pt-BR") == "pt-BR"
+        assert normalize_language("pt-PT") == "pt-PT"
+
+
 class TestSubtagSeparators:
     """The U+2011 in the old Traditional Chinese code renders close enough to
     both a hyphen and an underscore that either is a plausible thing to type."""


### PR DESCRIPTION
Addresses #1320.

## What

Adds `pt-BR` (Portuguese, Brazil) and `pt-PT` (Portuguese, Portugal) as distinct entries in `data/book-languages.json`, alongside the existing unqualified `pt`. This mirrors the `zh` / `zh-Hant` split already in the file.

```json
{ "language": "Portuguese", "code": "pt", "aliases": ["por"] },
{ "language": "Portuguese (Brazil)", "code": "pt-BR", "aliases": ["pt-br", "brazilian portuguese", "portugues brasileiro", "portugues (brasil)"] },
{ "language": "Portuguese (Portugal)", "code": "pt-PT", "aliases": ["pt-pt", "european portuguese", "portugues europeu", "portugues (portugal)"] },
```

## Why

`BOOK_LANGUAGE` treats Portuguese as one code, so Brazilian and European editions can't be told apart — they differ in translation, orthography and usually the title itself. Selecting `pt` still means "either / unspecified".

## Scope

Data + tests only. No behavioural change to how `&lang=` is built — the open questions from #1320 (pass `pt-BR` through as-is vs. widen to `lang=pt-BR OR lang=pt` and rank BR signals locally; whether to touch distant-path detection given `[BR]` collides with `br`=Breton) are left for discussion. Happy to follow up once there's a direction.

## Notes

- `_SUBTAG_SEPARATORS` in `languages.py` already handles it: `pt-BR`, `pt_BR`, and the Unicode-dash spellings all fold to `pt-BR`. Accented (`Português (Brasil)`) and English-name forms resolve via the aliases.
- `normalize_language("pt")` is unchanged (`pt` still first in the file; no shared folded alias).
- New `TestPortugueseVariants` in `tests/core/test_languages.py`.

## Checks

- `make python-test` — 2962 passed
- `make python-lint` / `make python-format` — clean
- `make python-typecheck` / vulture — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
